### PR TITLE
fix-upcoming-events

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,6 +13,7 @@
  *= require fullcalendar-3.9.0/fullcalendar.css
  *= require weekcalendar-2.0/jquery.weekcalendar.css
  *=
+ *= require @fortawesome/fontawesome-free/css/all.css
  *= require bulma/css/bulma.css
  *= require bulma-calendar/dist/css/bulma-calendar.min.css
  *= require megamenu.scss

--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -15,3 +15,7 @@
 .eventColumn {
   display: flex;
 }
+
+.eventCard {
+  box-shadow: 5px 5px 3px 1px rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(0, 0, 0, 0.1);
+}

--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -5,3 +5,13 @@
 .calendarContainer {
   padding: 25px;
 }
+
+.eventLink {
+  position: absolute;
+  top: 0; left: 0;
+  height: 100%; width: 100%;
+}
+
+.eventColumn {
+  display: flex;
+}

--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -6,16 +6,20 @@
   padding: 25px;
 }
 
-.eventLink {
-  position: absolute;
-  top: 0; left: 0;
-  height: 100%; width: 100%;
-}
-
 .eventColumn {
   display: flex;
 }
 
 .eventCard {
   box-shadow: 5px 5px 3px 1px rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(0, 0, 0, 0.1);
+}
+
+.eventCard a {
+  position: absolute;
+  top: 0; left: 0;
+  height: 100%; width: 100%;
+}
+
+.card-header-title span {
+  font-weight: normal;
 }

--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -2,24 +2,22 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-.calendarContainer {
-  padding: 25px;
-}
+.event-card {
+  box-shadow: 2px 2px 2px 1px rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(0, 0, 0, 0.1);
 
-.eventColumn {
-  display: flex;
-}
+  .card-header-title span {
+    font-weight: normal;
+  }
 
-.eventCard {
-  box-shadow: 5px 5px 3px 1px rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(0, 0, 0, 0.1);
-}
+  a {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+  }
 
-.eventCard a {
-  position: absolute;
-  top: 0; left: 0;
-  height: 100%; width: 100%;
-}
-
-.card-header-title span {
-  font-weight: normal;
+  .event-description {
+    height: 100px;
+  }
 }

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -47,19 +47,14 @@
 <% if @events.length > 0 %>
   <div class="columns">
     <% @events.each do |event| %>
-      <div class="column is-4">
-        <div class="card vertical-scroll" style="height: 300px;">
+      <div class="column is-4 eventColumn">
+        <div class="card">
+          <!-- a.eventLink makes entire card clickable, but messes with text selection -->
+          <a class="eventLink" href="<%= event.details_url %>"></a>
           <div class="card-content">
             <p><a class="title is-4" href="<%= event_path(event) %>"><%= event.name %></a></p>
 
             <div class="content">
-              <p>
-                <%= event.description %>
-                <% if not event.details_url.blank? %>
-                  <br>
-                  <%= link_to "More details", event.details_url %>
-                <% end %>
-              </p>
               <p>
                 <em>
                   <time><%= event.start.strftime("%A, %B %e") %></time>
@@ -71,6 +66,13 @@
                   <time><%= event.end.strftime("%l:%M%P") %></time>
                 </em>
               </p>
+
+              <p>
+                <strong>Location: </strong><%= event.location %><br>
+                <strong>Host: </strong><%= event.host %>
+              </p>
+
+              <p><%= event.description %></p>
             </div>
           </div>
         </div>

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -49,27 +49,37 @@
     <% @events.each do |event| %>
       <div class="column is-4 eventColumn">
         <div class="card eventCard">
-          <!-- a.eventLink makes entire card clickable, but messes with text selection -->
-          <a class="eventLink" href="<%= event.details_url %>"></a>
-          <div class="card-content">
-            <p><a class="title is-4" href="<%= event_path(event) %>"><%= event.name %></a></p>
+          <!-- <a> nested inside .eventCard makes entire card clickable, but messes with text selection -->
+          <a href="<%= event.details_url %>"></a>
 
+          <header class="card-header">
+            <p class="card-header-title">
+              <%= event.name %>
+            </p>
+          </header>
+
+          <div class="card-content">
             <div class="content">
               <p>
+                <em>Hosted by <%= event.host %></em>
+              </p>
+              <p>
                 <em>
+                  <i class="far fa-calendar"></i>
                   <time><%= event.start.strftime("%A, %B %e") %></time>
                 </em>
                 <br>
                 <em>
+                  <i class="far fa-clock"></i>
                   <time><%= event.start.strftime("%l:%M%P") %></time>
                   -
                   <time><%= event.end.strftime("%l:%M%P") %></time>
                 </em>
-              </p>
-
-              <p>
-                <strong>Location: </strong><%= event.location %><br>
-                <strong>Host: </strong><%= event.host %>
+                <br>
+                <em>
+                  <i class="fas fa-map-marker-alt"></i>
+                  <%= event.location %><br>
+                </em>
               </p>
 
               <p><%= event.description %></p>

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -47,10 +47,10 @@
 <% if @events.length > 0 %>
   <div class="columns">
     <% @events.each do |event| %>
-      <div class="column is-4 eventColumn">
-        <div class="card eventCard">
+      <div class="column is-4">
+        <div class="card event-card">
           <!-- <a> nested inside .eventCard makes entire card clickable, but messes with text selection -->
-          <a href="<%= event.details_url %>"></a>
+          <a href="<%= url_for(event) %>"></a>
 
           <header class="card-header">
             <p class="card-header-title">
@@ -60,9 +60,6 @@
 
           <div class="card-content">
             <div class="content">
-              <p>
-                <em>Hosted by <%= event.host %></em>
-              </p>
               <p>
                 <em>
                   <i class="far fa-calendar"></i>
@@ -82,7 +79,9 @@
                 </em>
               </p>
 
-              <p><%= event.description %></p>
+              <div class="event-description vertical-scroll" />
+                <p><%= event.description %></p>
+              </div>
             </div>
           </div>
         </div>

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -48,7 +48,7 @@
   <div class="columns">
     <% @events.each do |event| %>
       <div class="column is-4 eventColumn">
-        <div class="card">
+        <div class="card eventCard">
           <!-- a.eventLink makes entire card clickable, but messes with text selection -->
           <a class="eventLink" href="<%= event.details_url %>"></a>
           <div class="card-content">

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "aspc-v2",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.3.1",
     "bulma": "^0.7.1",
     "bulma-calendar": "^4.0.2",
     "slick-carousel": "^1.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@fortawesome/fontawesome-free@^5.3.1":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.3.1.tgz#5466b8f31c1f493a96754c1426c25796d0633dd9"
+
 bulma-calendar@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/bulma-calendar/-/bulma-calendar-4.0.2.tgz#a620811f5002bbb76e408788c03050ff6926cb67"


### PR DESCRIPTION
Entire events card is clickable, linking to host-provided URL.

Removed link to events detail page (/events/:id) and added missing details (location, host) to the upcoming events card, so that we don't have to link to two pages from a single card (details and host-provided URL). /events/:id endpoint should now only show when submitting an event.

Removed vertical scroll and added drop shadow to make events card look more clickable. Cards resize based on description length, so submissions should be vetted to make sure descriptions aren't overly long (they shouldn't too long anyway).