### PR TITLE
Reorganise menus

### DIFF
--- a/app/controllers/menu_controller.rb
+++ b/app/controllers/menu_controller.rb
@@ -1,11 +1,11 @@
 class MenuController < ApplicationController
   def index
-    @dining_hall = "frary"
+    @meal_type = "lunch"
     @day = Date.today.wday
   end
 
   def show
-    @dining_hall = params[:dining_hall]
+    @meal_type = params[:meal_type]
     @day = params[:day] || "sunday"
 
     respond_to do |format|

--- a/app/controllers/menu_controller.rb
+++ b/app/controllers/menu_controller.rb
@@ -6,7 +6,7 @@ class MenuController < ApplicationController
 
   def show
     @meal_type = params[:meal_type]
-    @day = params[:day] || "sunday"
+    @day = params[:day]
 
     respond_to do |format|
       format.js

--- a/app/views/menu/_dining_hall_menu.html.erb
+++ b/app/views/menu/_dining_hall_menu.html.erb
@@ -3,8 +3,24 @@
 
 <% menu_for_day_and_meal_type = Menu.where(:meal_type => meal_type).select {|x| x.day == day}.group_by(&:dining_hall) %>
 
-<% if menu_for_day_and_meal_type.length > 0 %>
+<!-- sort dining halls, placing frank and frary at the top and arranging the rest alphabetically -->
+<% sorted_menu = menu_for_day_and_meal_type.sort_by { |key, val| key } %>
+<%# frank_pos = 0 %>
+<%# frary_pos = 0 %>
+<%# sorted_menu.each_with_index {|menu, index| if menu[0] == 'frank' then frank_pos = index end} %>
+<%# sorted_menu.insert(0, sorted_menu.delete_at(frank_pos)) %>
+<%# sorted_menu.each_with_index {|menu, index| if menu[0] == 'frary' then frary_pos = index end} %>
+<%# sorted_menu.insert(0, sorted_menu.delete_at(frary_pos)) %>
+
+<!--<p>-->
+<!--  <b>Title:</b>-->
+  <%#= menu_for_day_and_meal_type['claremont_mckenna'] %>
+  <%#= @sorted_menu[0] %>
+<!--</p>-->
+
+<% if sorted_menu.length > 0 %>
 <% menu_for_day_and_meal_type.each do |dining_hall, menu| %>
+  <% if menu.first.menu_items[0] != nil %>
   <section class="box">
     <!-- replace '_' with ' ', capitalise each word, capitalise 'K' in 'McKenna'-->
     <h3 class="title"><%= dining_hall.split('_').map(&:capitalize).join(' ').sub('Mckenna', 'McKenna') %></h3>
@@ -22,6 +38,7 @@
       <% end %>
     </div>
   </section>
+  <% end %>
 <% end %>
 <% else %>
   <p>Closed today. Try another dining hall!</p>

--- a/app/views/menu/_dining_hall_menu.html.erb
+++ b/app/views/menu/_dining_hall_menu.html.erb
@@ -1,12 +1,12 @@
-<% dining_hall = local_assigns.fetch(:dining_hall) %>
+<% meal_type = local_assigns.fetch(:meal_type) %>
 <% day = local_assigns.fetch(:day) %>
 
-<% menu_for_day_and_dining_hall = Menu.where(:dining_hall => dining_hall).select {|x| x.day == day}.group_by(&:meal_type) %>
+<% menu_for_day_and_meal_type = Menu.where(:meal_type => meal_type).select {|x| x.day == day}.group_by(&:dining_hall) %>
 
-<% if menu_for_day_and_dining_hall.length > 0 %>
-<% menu_for_day_and_dining_hall.each do |meal_type, menu| %>
+<% if menu_for_day_and_meal_type.length > 0 %>
+<% menu_for_day_and_meal_type.each do |dining_hall, menu| %>
   <section class="box">
-    <h3 class="title"><%= meal_type.capitalize %></h3>
+    <h3 class="title"><%= dining_hall.capitalize %></h3>
 
     <div class="columns horizontal-scroll">
       <% menu.first.menu_items.group_by(&:station).sort_by{|k,v| v.length}.reverse.each_with_index do |(station, menu_items), index| %>

--- a/app/views/menu/_dining_hall_menu.html.erb
+++ b/app/views/menu/_dining_hall_menu.html.erb
@@ -6,7 +6,8 @@
 <% if menu_for_day_and_meal_type.length > 0 %>
 <% menu_for_day_and_meal_type.each do |dining_hall, menu| %>
   <section class="box">
-    <h3 class="title"><%= dining_hall.capitalize %></h3>
+    <!-- replace '_' with ' ', capitalise each word, capitalise 'K' in 'McKenna'-->
+    <h3 class="title"><%= dining_hall.split('_').map(&:capitalize).join(' ').sub('Mckenna', 'McKenna') %></h3>
 
     <div class="columns horizontal-scroll">
       <% menu.first.menu_items.group_by(&:station).sort_by{|k,v| v.length}.reverse.each_with_index do |(station, menu_items), index| %>

--- a/app/views/menu/_dining_hall_menu.html.erb
+++ b/app/views/menu/_dining_hall_menu.html.erb
@@ -18,9 +18,12 @@
   <%#= @sorted_menu[0] %>
 <!--</p>-->
 
+<% menus_are_displayed = false %>
+
 <% if sorted_menu.length > 0 %>
 <% menu_for_day_and_meal_type.each do |dining_hall, menu| %>
   <% if menu.first.menu_items[0] != nil %>
+  <% menus_are_displayed = true %>
   <section class="box">
     <!-- replace '_' with ' ', capitalise each word, capitalise 'K' in 'McKenna'-->
     <h3 class="title"><%= dining_hall.split('_').map(&:capitalize).join(' ').sub('Mckenna', 'McKenna') %></h3>
@@ -40,6 +43,8 @@
   </section>
   <% end %>
 <% end %>
-<% else %>
-  <p>Closed today. Try another dining hall!</p>
+<% end %>
+
+<% if !menus_are_displayed %>
+  <p>No dining halls open at this time. Try another time!</p>
 <% end %>

--- a/app/views/menu/_dining_hall_menu.html.erb
+++ b/app/views/menu/_dining_hall_menu.html.erb
@@ -3,32 +3,22 @@
 
 <% menu_for_day_and_meal_type = Menu.where(:meal_type => meal_type).select {|x| x.day == day}.group_by(&:dining_hall) %>
 
-<!-- sort dining halls, placing frank and frary at the top and arranging the rest alphabetically -->
+<!-- sort dining halls alphabetically -->
 <% sorted_menu = menu_for_day_and_meal_type.sort_by { |key, val| key } %>
-<%# frank_pos = 0 %>
-<%# frary_pos = 0 %>
-<%# sorted_menu.each_with_index {|menu, index| if menu[0] == 'frank' then frank_pos = index end} %>
-<%# sorted_menu.insert(0, sorted_menu.delete_at(frank_pos)) %>
-<%# sorted_menu.each_with_index {|menu, index| if menu[0] == 'frary' then frary_pos = index end} %>
-<%# sorted_menu.insert(0, sorted_menu.delete_at(frary_pos)) %>
 
-<!--<p>-->
-<!--  <b>Title:</b>-->
-  <%#= menu_for_day_and_meal_type['claremont_mckenna'] %>
-  <%#= @sorted_menu[0] %>
-<!--</p>-->
-
+<!-- a bool to keep track of whether or not there are any menus in currently selected meal time -->
+<!-- display message at the end if not -->
 <% menus_are_displayed = false %>
 
 <% if sorted_menu.length > 0 %>
-<% menu_for_day_and_meal_type.each do |dining_hall, menu| %>
+<% sorted_menu.each do |dining_hall, menu| %>
   <% if menu.first.menu_items[0] != nil %>
   <% menus_are_displayed = true %>
   <section class="box">
     <!-- replace '_' with ' ', capitalise each word, capitalise 'K' in 'McKenna'-->
     <h3 class="title"><%= dining_hall.split('_').map(&:capitalize).join(' ').sub('Mckenna', 'McKenna') %></h3>
 
-    <div class="columns horizontal-scroll">
+    <div class="columns is-multiline">
       <% menu.first.menu_items.group_by(&:station).sort_by{|k,v| v.length}.reverse.each_with_index do |(station, menu_items), index| %>
         <div class="column is-3">
           <h4 class="subtitle is-4"><%= station %></h4>

--- a/app/views/menu/index.html.erb
+++ b/app/views/menu/index.html.erb
@@ -3,32 +3,9 @@
 <% end %>
 
 <%= form_with url: '', remote: true, id: 'menu-form' do |f| %>
-<%= f.hidden_field :dining_hall, :value => '', :id => 'dining-hall-field' %>
+<%= f.hidden_field :meal_type, :value => '', :id => 'meal-type-field' %>
 <%= f.hidden_field :day, :value => '', :id => 'menu-day-field' %>
 <div class="tabs is-centered is-boxed is-medium">
-  <ul id="dining-hall-buttons">
-    <li>
-      <%= content_tag(:a, 'Frank', :name => 'submit', :class => 'dining-hall-link-button', :data => {:endpoint => '/menus/frank', :dining_hall => 'frank'}) %>
-    </li>
-    <li class="is-active">
-      <%= content_tag(:a, 'Frary', :name => 'submit', :class => 'dining-hall-link-button', :data => {:endpoint => '/menus/frary', :dining_hall => 'frary'}) %>
-    </li>
-    <li>
-      <%= content_tag(:a, 'Claremont McKenna', :name => 'submit', :class => 'dining-hall-link-button', :data => {:endpoint => '/menus/claremont_mckenna', :dining_hall => 'claremont_mckenna'}) %>
-    </li>
-    <li>
-      <%= content_tag(:a, 'Harvey Mudd', :name => 'submit', :class => 'dining-hall-link-button', :data => {:endpoint => '/menus/harvey_mudd', :dining_hall => 'harvey_mudd'}) %>
-    </li>
-    <li>
-      <%= content_tag(:a, 'Scripps', :name => 'submit', :class => 'dining-hall-link-button', :data => {:endpoint => '/menus/scripps', :dining_hall => 'scripps'}) %>
-    </li>
-    <li>
-      <%= content_tag(:a, 'Pitzer', :name => 'submit', :class => 'dining-hall-link-button', :data => {:endpoint => '/menus/pitzer', :dining_hall => 'pitzer'}) %>
-    </li>
-  </ul>
-</div>
-
-<div class="tabs is-centered is-toggle is-fullwidth is-small">
   <ul id="day-menu-buttons">
     <li <% if @day == 0 %>class="is-active"<% end %>>
       <%= content_tag(:a, 'Sunday', :name => 'submit', :class => 'menu-day-button') %>
@@ -53,12 +30,29 @@
     </li>
   </ul>
 </div>
+
+<div class="tabs is-centered is-toggle is-fullwidth is-small">
+  <ul id="meal-type-buttons">
+    <li>
+      <%= content_tag(:a, 'Breakfast', :name => 'submit', :class => 'meal-type-button', :data => {:endpoint => '/menus/breakfast', :meal_type => 'breakfast'}) %>
+    </li>
+    <li>
+      <%= content_tag(:a, 'Brunch', :name => 'submit', :class => 'meal-type-button', :data => {:endpoint => '/menus/brunch', :meal_type => 'brunch'}) %>
+    </li>
+    <li class="is-active">
+      <%= content_tag(:a, 'Lunch', :name => 'submit', :class => 'meal-type-button', :data => {:endpoint => '/menus/lunch', :meal_type => 'lunch'}) %>
+    </li>
+    <li>
+      <%= content_tag(:a, 'Dinner', :name => 'submit', :class => 'meal-type-button', :data => {:endpoint => '/menus/dinner', :meal_type => 'dinner'}) %>
+    </li>
+  </ul>
+</div>
 <% end %>
 
 <br>
 
 <div id="dining-hall-menu-container">
-  <%= render 'menu/dining_hall_menu', :dining_hall => @dining_hall, :day => @day %>
+  <%= render 'menu/dining_hall_menu', :meal_type => @meal_type, :day => @day %>
 </div>
 
 <script>
@@ -66,26 +60,27 @@
     function submitMenuForm() {
         // Fetch the elements we will be operating on
         let selectedDayElement = $('#day-menu-buttons li.is-active a');
-        let selectedDiningHallElement = $('#dining-hall-buttons li.is-active a');
+        let selectedMealTypeElement = $('#meal-type-buttons li.is-active a');
 
         // Set the day of week to fetch menu for
         let selectedDay = selectedDayElement.text().trim().toLowerCase();
         $('#menu-day-field').val(selectedDay);
 
         // Set the dining hall to fetch menu for
-        let selectedDiningHall = selectedDiningHallElement.data('diningHall');
-        $('#dining-hall-field').val(selectedDiningHall);
+        let selectedMealType = selectedMealTypeElement.text().trim().toLowerCase();
+        $('#meal-type-field').val(selectedMealType);
 
         // Submit the form
         let form = $('#menu-form');
-        let endpointURL = selectedDiningHallElement.data('endpoint');
+        // let endpointURL = selectedDiningHallElement.data('endpoint');
+        let endpointURL = selectedMealTypeElement.data('endpoint')
         form.attr('action', endpointURL);
         Rails.fire(form[0], 'submit');
     }
 
-    $('.dining-hall-link-button').click(function () {
+    $('.menu-day-button').click(function () {
         // Set the active tab
-        $('.dining-hall-link-button').parent().each(function () {
+        $('.menu-day-button').parent().each(function () {
             $(this).removeClass('is-active');
         });
         $(this).parent().toggleClass('is-active');
@@ -94,9 +89,9 @@
         submitMenuForm();
     });
 
-    $('.menu-day-button').click(function () {
+    $('.meal-type-button').click(function() {
         // Set the active tab
-        $('.menu-day-button').parent().each(function () {
+        $('.meal-type-button').parent().each(function() {
             $(this).removeClass('is-active');
         });
         $(this).parent().toggleClass('is-active');

--- a/app/views/menu/show.js.erb
+++ b/app/views/menu/show.js.erb
@@ -1,2 +1,2 @@
 $('#dining-hall-menu-container')
-    .html("<%= j render 'menu/dining_hall_menu', dining_hall: @dining_hall, day: @day %>");
+    .html("<%= j render 'menu/dining_hall_menu', meal_type: @meal_type, day: @day %>");

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   scope controller: :menu do
     get 'menus' => :index
     match 'menus/:dining_hall' => :show, :via => [:get, :post]
+    match 'menus/:meal_type' => :show, :via => [:get, :post]
   end
 
   scope controller: :sessions do


### PR DESCRIPTION
Added a new endpoint for /menus/:meal_type, hidden form in views/menu/index.html POSTs to the new meal_type endpoint instead of the old dining_hall endpoint. Fixed up some bugs with empty dining hall menus displaying, and replaced horizontal scrolling on menus with overflowing to the next line.