### PR TITLE
Hide horizontal scrollbar in events card when not needed

### DIFF
--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -58,7 +58,7 @@
 
           <div class="card-content">
             <div class="content">
-              <p class="horizontal-scroll">
+              <p class="horizontal-scroll" style="overflow: auto">
                 <em>
                   <%= fa_icon "calendar" %>
                   <time><%= event.start.strftime("%A, %B %e") %></time>
@@ -77,7 +77,7 @@
                 </em>
               </p>
 
-              <div class="event-description vertical-scroll" />
+              <div class="event-description vertical-scroll" style="overflow: auto;">
                 <p><%= event.description %></p>
               </div>
             </div>


### PR DESCRIPTION
Problem: heights don't match if some cards have horizontal scrollbars and others don't