### PR TITLE
Export course schedule

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,9 @@ gem 'font-awesome-rails', '~> 4.7.0'
 # Session persistence
 gem 'activerecord-session_store', '~> 1.1.1'
 
+# Calendar export
+gem 'icalendar'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,9 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
+    icalendar (2.5.2)
+      ice_cube (~> 0.16)
+    ice_cube (0.16.3)
     inherited_resources (1.9.0)
       actionpack (>= 4.2, < 5.3)
       has_scope (~> 0.6)
@@ -304,6 +307,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   font-awesome-rails (~> 4.7.0)
   httparty (~> 0.16.2)
+  icalendar
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
@@ -325,4 +329,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.16.4
+   2.0.1

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -21,6 +21,9 @@
  *= require slick-carousel/slick/slick.css
  *= require slick-carousel/slick/slick-theme.css
  *
+ * Sass helpers file
+ *= require helpers.scss
+ *
  * Page specific styles here
  *= require events.scss
  *= require sessions.scss

--- a/app/assets/stylesheets/helpers.scss
+++ b/app/assets/stylesheets/helpers.scss
@@ -1,0 +1,11 @@
+// Spacing helpers
+@each $size in (0,1,2,3,4,5,10) {
+  @each $pos in ('top','right','bottom','left') {
+    .margin-#{$pos}-#{$size} {
+      margin-#{$pos}: $size + rem !important;
+    }
+    .padding-#{$pos}-#{$size} {
+      padding-#{$pos}: $size + rem !important;
+    }
+  }
+}

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -14,7 +14,59 @@ class CoursesController < ApplicationController
     @course = Course.find(params[:id])
   end
 
-  # TODO: Move to course schedule controller ?
+  def export_course_sections
+    academic_term = AcademicTerm.find_by(:session => params[:session], :year => params[:year])
+    puts academic_term.inspect
+    user_course_schedule = CourseSchedule.find_or_create_by(:user => current_user)
+    course_sections = user_course_schedule.course_sections.includes(:course_meeting_details).where.not(course_meeting_details: {course_section_id: nil})
+
+    calendar = Icalendar::Calendar.new
+    calendar.version = '2.0'
+    filename = "#{academic_term.session.parameterize}-#{academic_term.year}-courses.ics"
+
+    case academic_term
+    when "FA 2018"
+      term_start = DateTime.new(2018, 9, 4, 8, 10, 0)
+      term_end = DateTime.new(2018, 12, 12, 22, 0, 0)
+    else
+      term_start = DateTime.new(2019, 1, 22, 8, 10, 0)
+      term_end = DateTime.new(2019, 5, 8, 22, 0, 0)
+    end
+
+    (term_start..term_end).each do |date|
+      # Do stuff with date
+      course_sections.each do |course_section|
+        course_section.course_meeting_details.each do |detail|
+          case date.strftime("%w")
+          when "1"
+            if detail.monday
+              new_calendar_event(calendar, date, course_section, detail)
+            end
+          when "2"
+            if detail.tuesday
+              new_calendar_event(calendar, date, course_section, detail)
+            end
+          when "3"
+            if detail.wednesday
+              new_calendar_event(calendar, date, course_section, detail)
+            end
+          when "4"
+            if detail.thursday
+              new_calendar_event(calendar, date, course_section, detail)
+            end
+          when "5"
+            if detail.friday
+              new_calendar_event(calendar, date, course_section, detail)
+            end
+          end
+        end
+      end
+    end
+
+    send_data calendar.to_ical, type: 'text/calendar', disposition: 'attachment', filename: filename
+  end
+
+# TODO: Move to course schedule controller ?
   def add_course_section_to_schedule
     section_id = params[:section_id]
     @course_section = CourseSection.find_by(:id => section_id)
@@ -30,7 +82,7 @@ class CoursesController < ApplicationController
     end
   end
 
-  # TODO: Move to course schedule controller ?
+# TODO: Move to course schedule controller ?
   def remove_course_section_from_schedule
     @course_schedule = CourseSchedule.find_or_create_by(:user => current_user)
 
@@ -43,7 +95,7 @@ class CoursesController < ApplicationController
     end
   end
 
-  # TODO: Move to course schedule controller ?
+# TODO: Move to course schedule controller ?
   def clear_course_sections_from_schedule
     @course_schedule = CourseSchedule.find_or_create_by(:user => current_user)
     @course_schedule.course_sections.delete(*@course_schedule.course_sections)
@@ -53,9 +105,9 @@ class CoursesController < ApplicationController
     end
   end
 
-  # TODO: Move to course schedule controller ?
-  # This method is actually completely redundant,
-  # but mas as well provide a placebo / verification
+# TODO: Move to course schedule controller ?
+# This method is actually completely redundant,
+# but mas as well provide a placebo / verification
   def save_course_sections_to_schedule
     respond_to do |format|
       format.js {flash.now[:notice] = "Schedule saved successfully."}
@@ -106,7 +158,7 @@ class CoursesController < ApplicationController
         :tuesday => params[:schools].include?("Tuesday") || false,
         :wednesday => params[:schools].include?("Wednesday") || false,
         :thursday => params[:schools].include?("Thursday") || false,
-        :friday => params[:schools].include?("Friday")|| false
+        :friday => params[:schools].include?("Friday") || false
     }
     days.select! {|k, v| v}
 
@@ -158,4 +210,18 @@ class CoursesController < ApplicationController
       format.js
     end
   end
+
+  private
+
+  def new_calendar_event(calendar, date, course_section, detail)
+    event = calendar.event
+    event.summary = course_section.course.code + " " + course_section.course.name
+    start_time = DateTime.new(date.year, date.month, date.day, detail.start_time.hour, detail.start_time.min, 0)
+    end_time = DateTime.new(date.year, date.month, date.day, detail.end_time.hour, detail.end_time.min, 0)
+    event.dtstart = Icalendar::Values::DateTime.new(start_time)
+    event.dtend = Icalendar::Values::DateTime.new(end_time)
+    event.description = course_section.description
+    event.location = detail.location
+  end
+
 end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -16,15 +16,15 @@ class CoursesController < ApplicationController
 
   def export_course_sections
     academic_term = AcademicTerm.find_by(:session => params[:session], :year => params[:year])
-    puts academic_term.inspect
     user_course_schedule = CourseSchedule.find_or_create_by(:user => current_user)
     course_sections = user_course_schedule.course_sections.includes(:course_meeting_details).where.not(course_meeting_details: {course_section_id: nil})
 
     calendar = Icalendar::Calendar.new
-    calendar.version = '2.0'
+    calendar.version = "2.0"
     filename = "#{academic_term.session.parameterize}-#{academic_term.year}-courses.ics"
 
-    case academic_term
+    academic_term_session_year = "#{academic_term.session} #{academic_term.year}"
+    case academic_term_session_year
     when "FA 2018"
       term_start = DateTime.new(2018, 9, 4, 8, 10, 0)
       term_end = DateTime.new(2018, 12, 12, 22, 0, 0)
@@ -34,8 +34,7 @@ class CoursesController < ApplicationController
     end
 
     (term_start..term_end).each do |date|
-      # Do stuff with date
-      course_sections.each do |course_section|
+       course_sections.each do |course_section|
         course_section.course_meeting_details.each do |detail|
           case date.strftime("%w")
           when "1"
@@ -63,7 +62,7 @@ class CoursesController < ApplicationController
       end
     end
 
-    send_data calendar.to_ical, type: 'text/calendar', disposition: 'attachment', filename: filename
+    send_data calendar.to_ical, type: "text/calendar", disposition: "attachment", filename: filename
   end
 
 # TODO: Move to course schedule controller ?
@@ -215,7 +214,7 @@ class CoursesController < ApplicationController
 
   def new_calendar_event(calendar, date, course_section, detail)
     event = calendar.event
-    event.summary = course_section.course.code + " " + course_section.course.name
+    event.summary = "#{course_section.course.code} #{course_section.course.name}"
     start_time = DateTime.new(date.year, date.month, date.day, detail.start_time.hour, detail.start_time.min, 0)
     end_time = DateTime.new(date.year, date.month, date.day, detail.end_time.hour, detail.end_time.min, 0)
     event.dtstart = Icalendar::Values::DateTime.new(start_time)

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -30,6 +30,22 @@
                     :class => "button",
                     :method => :post,
                     :remote => true %>
+      <a class="button modal-open" data-target="export-schedule-modal">Export Schedule</a>
     </div>
   </div>
+</div>
+
+<div class="modal" id="export-schedule-modal">
+  <div class="modal-background"></div>
+  <div class="modal-content">
+    <div class="modal-card">
+      <div class="box">
+        <h4 class="title is-4">Export Schedule</h4>
+        <% @academic_terms.each do |term| %>
+        <%= link_to "Export #{term.session} #{term.year}", courses_export_url(:session => term.session, :year => term.year), method: :get, class: "button is-outlined" %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+  <button class="modal-close is-large" aria-label="close"></button>
 </div>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -41,9 +41,16 @@
     <div class="modal-card">
       <div class="box">
         <h4 class="title is-4">Export Schedule</h4>
-        <% @academic_terms.each do |term| %>
-        <%= link_to "Export #{term.session} #{term.year}", courses_export_url(:session => term.session, :year => term.year), method: :get, class: "button is-outlined" %>
-        <% end %>
+        <p class="margin-bottom-1">
+          Choose a semester to export. Classes in exported calendar wil start and end on dates noted in
+          <a href="http://catalog.pomona.edu/content.php?catoid=28&navoid=5708">Academic Calendar</a>. You can import
+          iCalendar file into Google Calendar, Microsoft Outlook, iOS Calendar, macOS Calendar and more.
+        </p>
+        <div class="export-buttons">
+          <% @academic_terms.each do |term| %>
+            <%= link_to "#{term.session} #{term.year}", courses_export_url(:session => term.session, :year => term.year), method: :get, class: "button is-outlined" %>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
 
   scope controller: :courses do
     get 'courses' => :index
+    get 'courses/export' => :export_course_sections
     get 'courses/:id' => :show, as: :course
     post 'courses/add' => :add_course_section_to_schedule
     post 'courses/remove' => :remove_course_section_from_schedule


### PR DESCRIPTION
Implemented a controller action that enables users to export their course schedules to iCalendar file. Since iCalendar gem does not provide a feature for recurring events, course meetings on different weeks are added to the file as different events. However, I was not sure about other ways to go about this.

At this point, the dates when two last semesters start and end are hard coded in `courses_controller.rb`. I am not sure how courses API works, but we could change `course_import.rake` and model to hold that information as well and then use that in the controller. 