### PR TITLE
Cleanup static controller

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,8 +1,4 @@
 class StaticController < ApplicationController
-  require 'rss'
-  require 'open-uri'
-  require 'nokogiri'
-
   # Custom form in activeadmin breaks CSRF
   # This is a workaround while we figure out a better solution
   # skip_before_action :verify_authenticity_token, :only => [:upload_image]
@@ -96,6 +92,9 @@ class StaticController < ApplicationController
   private
 
   def news
+    require 'rss'
+    require 'open-uri'
+
     rss_results = []
     rss = RSS::Parser.parse(open("https://tsl.news/feed").read, false).items[0..2]
 

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -3,8 +3,6 @@ class StaticController < ApplicationController
   require 'open-uri'
   require 'nokogiri'
 
-  # NEW - froala
-
   # Custom form in activeadmin breaks CSRF
   # This is a workaround while we figure out a better solution
   # skip_before_action :verify_authenticity_token, :only => [:upload_image]
@@ -12,10 +10,6 @@ class StaticController < ApplicationController
 
   # Reference: https://github.com/froala/editor-ruby-sdk-example
   # https://www.froala.com/wysiwyg-editor/docs/sdks/ruby/image-server-upload
-
-  # Index.
-  def index
-  end
 
   def show
     if params[:id]
@@ -81,8 +75,8 @@ class StaticController < ApplicationController
     render :json => FroalaEditorSDK::Image.delete(params[:src], "public/uploads/")
   end
 
-  # OLD - hand-coded static pages
-
+  ##
+  # Custom actions for special, hardcoded views
   def index
     @announcements = Announcement.all
     time = Time.parse(Time.now.in_time_zone("Pacific Time (US & Canada)").strftime('%Y-%m-%d %H:%M:%S')).to_s(:db)
@@ -90,11 +84,11 @@ class StaticController < ApplicationController
     @news = news
   end
 
-  def aspc_senators
+  def senators
     @senators = Person.senator.order("id ASC")
   end
 
-  def aspc_staff
+  def staff
     @staff = Person.staff.order("id ASC")
     @board = Person.board.order("id ASC")
   end
@@ -113,5 +107,4 @@ class StaticController < ApplicationController
     end
     return rss_results
   end
-
 end

--- a/app/views/components/_application_header.html.erb
+++ b/app/views/components/_application_header.html.erb
@@ -94,10 +94,10 @@
             <div class="column">
               <h1 class="title is-6 is-mega-menu-title">Who We Are</h1>
               <div class="navbar-content">
-                <%= link_to "Senators", static_path(page_name: "senators"), :class => "navbar-item" %>
+                <%= link_to "Senators", senators_path, :class => "navbar-item" %>
               </div>
               <div class="navbar-content">
-                <%= link_to "Staff Members", static_path(page_name: "staff"), :class => "navbar-item" %>
+                <%= link_to "Staff Members", staff_path, :class => "navbar-item" %>
               </div>
               <div class="navbar-content">
                 <%= link_to "Committee Members", static_path(page_name: "committee"), :class => "navbar-item" %>

--- a/app/views/static/senators.html.erb
+++ b/app/views/static/senators.html.erb
@@ -1,0 +1,52 @@
+<% content_for :header do %>
+    <%= render 'components/page_header', :title => "Senators" %>
+<% end %>
+
+<% @senators.in_groups_of(3, false).each do |group| %>
+    <div class="columns">
+      <% group.each do |senator| %>
+        <div class="column is-4">
+          <div class="card">
+            <div class="card-image">
+              <figure class="image senator-image">
+                <%= avatar_photo senator %>
+              </figure>
+            </div>
+            <div class="card-content">
+              <div class="media">
+                <div class="media-content">
+                  <h5 class="title is-5 margin-bottom-2">
+                    <%= senator.name %></h5>
+                  <h6 class="subtitle is-6 has-text-weight-semibold margin-bottom-0">
+                    <%= senator.position %></h6>
+                  <h6 class="subtitle is-6 margin-bottom-1">
+                    <%= senator.email %></h6>
+                  <% if senator.biography.empty? %>
+                    <span class="button is-static">Biography</span>
+                  <% else %>
+                    <a class="button is-info is-outlined modal-open"
+                       data-target="<%= senator.name.parameterize %>-biography">Biography</a>
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <% if not senator.biography.empty? %>
+          <div class="modal" id="<%= senator.name.parameterize %>-biography">
+            <div class="modal-background"></div>
+            <div class="modal-content">
+              <div class="box">
+                <h4 class="title is-4">
+                  <%= senator.name %></h4>
+                <p>
+                  <%= senator.biography %></p>
+              </div>
+            </div>
+            <button class="modal-close is-large" aria-label="close"></button>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>

--- a/app/views/static/staff.html.erb
+++ b/app/views/static/staff.html.erb
@@ -1,0 +1,107 @@
+<% content_for :header do %>
+    <%= render 'components/page_header', :title => "Staff" %>
+<% end %>
+
+<h3 class="title is-3 margin-bottom-2">ASPC Staff</h3>
+<% @staff.in_groups_of(3, false).each do |group| %>
+    <div class="columns">
+      <% group.each do |member| %>
+        <div class="column is-4">
+          <div class="card">
+            <div class="card-image">
+              <figure class="image senator-image">
+                <%= avatar_photo member %>
+              </figure>
+            </div>
+            <div class="card-content">
+              <div class="media">
+                <div class="media-content">
+                  <h5 class="title is-5 margin-bottom-2">
+                    <%= member.name %></h5>
+                  <h6 class="subtitle is-6 has-text-weight-semibold margin-bottom-0">
+                    <%= member.position %></h6>
+                  <h6 class="subtitle is-6 margin-bottom-1">
+                    <%= member.email %></h6>
+                  <% if member.biography.empty? %>
+                    <span class="button is-static">Biography</span>
+                  <% else %>
+                    <a class="button is-info is-outlined modal-open"
+                       data-target="<%= member.name.parameterize %>-biography">Biography</a>
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <% if not member.biography.empty? %>
+          <div class="modal" id="<%= member.name.parameterize %>-biography">
+            <div class="modal-background"></div>
+            <div class="modal-content">
+              <div class="modal-card">
+                <div class="box">
+                  <h4 class="title is-4">
+                    <%= member.name %></h4>
+                  <p>
+                    <%= member.biography %></p>
+                </div>
+              </div>
+            </div>
+            <button class="modal-close is-large" aria-label="close"></button>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+<% end %>
+
+<h3 class="title is-3 margin-bottom-2">Board of Trustees Representatives</h3>
+<% @board.in_groups_of(3, false).each do |group| %>
+    <div class="columns">
+      <% group.each do |member| %>
+        <div class="column is-4">
+          <div class="card">
+            <div class="card-image">
+              <figure class="image senator-image">
+                <%= avatar_photo member %>
+              </figure>
+            </div>
+            <div class="card-content">
+              <div class="media">
+                <div class="media-content">
+                  <h5 class="title is-5 margin-bottom-2">
+                    <%= member.name %></h5>
+                  <h6 class="subtitle is-6 has-text-weight-semibold margin-bottom-0">
+                    <%= member.position %></h6>
+                  <h6 class="subtitle is-6 margin-bottom-1">
+                    <%= member.email %></h6>
+                  <% if member.biography.empty? %>
+                    <span class="button is-static">Biography</span>
+                  <% else %>
+                    <a class="button is-info is-outlined modal-open"
+                       data-target="<%= member.name.parameterize %>-biography">Biography</a>
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <% if not member.biography.empty? %>
+          <div class="modal" id="<%= member.name.parameterize %>-biography">
+            <div class="modal-background"></div>
+            <div class="modal-content">
+              <div class="modal-card">
+                <div class="box">
+                  <h4 class="title is-4">
+                    <%= member.name %></h4>
+                  <p>
+                    <%= member.biography %></p>
+                </div>
+              </div>
+            </div>
+            <button class="modal-close is-large" aria-label="close"></button>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,8 +70,12 @@ Rails.application.routes.draw do
   end
 
   scope controller: :static do
+    # Hardcoded pages not created via the CMS
     get 'index' => :index
+    get 'senators' => :senators
+    get 'staff' => :staff
 
+    # Editable pages created via the CMS
     get 'pages/id/:id' => :show, as: :static_page
     get 'pages/:page_name' => :show, as: :static
 


### PR DESCRIPTION
Tying up loose ends from #152, namely adding back the `staff` and `senators` pages as dedicated hardcoded pages (we simply update the models instead). 

Also clean up `StaticController`