### PR TITLE
Checking existence of database credentials before trying to access key

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -82,6 +82,8 @@ test:
 #
 production:
   <<: *default
-  database: aspc_production
-  username: aspc
-  password: <%= Rails.application.credentials[:database_credentials][:production] %>
+  <% if Rails.application.credentials[:database_credentials].present? %>
+    database: aspc_production
+    username: aspc
+    password: <%= Rails.application.credentials[:database_credentials][:production] %>
+  <% end %>


### PR DESCRIPTION
This fixes the issue for first-time contributors who are setting up.
Fixes #162