### PR TITLE
Hotfix/#165 menu deselection

### DIFF
--- a/app/views/menu/index.html.erb
+++ b/app/views/menu/index.html.erb
@@ -66,7 +66,7 @@
 		let selectedDay = selectedDayElement.text().trim().toLowerCase();
 		$('#menu-day-field').val(selectedDay);
 
-		// Set the dining hall to fetch menu for
+		// Set the type of meal to fetch menu for
 		let selectedMealType = selectedMealTypeElement.text().trim().toLowerCase();
 		$('#meal-type-field').val(selectedMealType);
 
@@ -101,6 +101,22 @@
 				$(this).removeClass('is-active');
 		});
 		$(this).parent().toggleClass('is-active');
+		day = $(this).parent().text().trim().toLowerCase();
+
+		// Fix the meal type if necessary
+		$('.meal-type-button').parent().each(function() {
+			if ($(this).attr('class') == 'is-active') {
+				isWeekend = day == 'saturday' || day == 'sunday';
+				isBreakfastOrLunch = $(this).attr('id') == 'breakfast-button' || $(this).attr('id') == 'lunch-button';
+				if (isWeekend && isBreakfastOrLunch) {
+					$(this).removeClass('is-active');
+					$('#brunch-button').toggleClass('is-active');
+				} else if (!isWeekend && $(this).attr('id') == 'brunch-button') {
+					$(this).removeClass('is-active');
+					$('#breakfast-button').toggleClass('is-active');
+				}
+			};
+		});
 
 		// Submit the form
 		submitMenuForm();

--- a/app/views/menu/index.html.erb
+++ b/app/views/menu/index.html.erb
@@ -115,7 +115,7 @@
 					$(this).removeClass('is-active');
 					$('#breakfast-button').toggleClass('is-active');
 				}
-			};
+			}
 		});
 
 		// Submit the form


### PR DESCRIPTION
Switching to Saturday/Sunday with Breakfast/Lunch selected will auto-select Brunch. Switching to a weekday with Brunch selected will auto-select Breakfast. 

Pros: No confusing deselection issue
Cons: It doesn't save your last state. If you were on Friday Lunch and tabbed onto Sunday's menu, and came back to Friday, you would now be at Breakfast (the weekend to weekday selection is hard-coded to be breakfast). 

If this fix is not good enough, I can explore saving the state somehow.

Fixes #165