### PR TITLE
Announcements ordering by priority

### DIFF
--- a/app/admin/announcements.rb
+++ b/app/admin/announcements.rb
@@ -1,6 +1,6 @@
 announcements_page = Proc.new do
   menu :priority => 2
-  permit_params :title, :caption, :background_image, :details_url
+  permit_params :title, :caption, :background_image, :details_url, :priority
 
   form do |f|
     f.inputs
@@ -13,6 +13,7 @@ announcements_page = Proc.new do
       row :title
       row :caption
       row :details_url
+      row :priority
       row :background_image do |announcement|
         image_tag url_for(announcement.background_image), :width => '100%'
       end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -74,7 +74,7 @@ class StaticController < ApplicationController
   ##
   # Custom actions for special, hardcoded views
   def index
-    @announcements = Announcement.all
+    @announcements = Announcement.priority_order.all
     time = Time.parse(Time.now.in_time_zone("Pacific Time (US & Canada)").strftime('%Y-%m-%d %H:%M:%S')).to_s(:db)
     @events = Event.where("start >= ?", time).where(:status => :approved).order(:start).take(3)
     @news = news

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,3 +1,4 @@
 class Announcement < ApplicationRecord
+  scope :priority_order, -> {order(priority: :asc)}
   has_one_attached :background_image
 end

--- a/db/migrate/20190911061539_add_priority_to_announcements.rb
+++ b/db/migrate/20190911061539_add_priority_to_announcements.rb
@@ -1,0 +1,5 @@
+class AddPriorityToAnnouncements < ActiveRecord::Migration[5.2]
+  def change
+    add_column :announcements, :priority, :integer
+  end
+end


### PR DESCRIPTION
Solves #168. Created a database migration to add a priority column to announcements table and a priority field to announcements page in Active Admin. Sorted announcements in static controller according to priority column.