### PR TITLE
Senators and staff ordering by priority

### DIFF
--- a/app/admin/people.rb
+++ b/app/admin/people.rb
@@ -2,7 +2,7 @@ senators_page = Proc.new do
   menu :priority => 5, :label => "ASPC Senators and Staff"
 
   # TODO: allow associating with a user model
-  permit_params :name, :position, :role, :email, :biography, :image
+  permit_params :name, :position, :role, :email, :biography, :image, :priority
 
   form do |f|
     f.inputs
@@ -17,6 +17,7 @@ senators_page = Proc.new do
       row :role
       row :email
       row :biography
+      row :priority
       row :image do |person|
         if (person.image.attached?)
           image_tag url_for(person.image)

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -81,12 +81,12 @@ class StaticController < ApplicationController
   end
 
   def senators
-    @senators = Person.senator.order("id ASC")
+    @senators = Person.priority_order.order("id ASC")
   end
 
   def staff
-    @staff = Person.staff.order("id ASC")
-    @board = Person.board.order("id ASC")
+    @staff = Person.priority_order.staff.order("id ASC")
+    @board = Person.priority_order.board.order("id ASC")
   end
 
   private

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,4 +1,5 @@
 class Person < ApplicationRecord
   enum role: [:senator, :staff, :board]
+  scope :priority_order, -> {order(priority: :asc)}
   has_one_attached :image
 end

--- a/db/migrate/20190912005931_add_priority_to_person.rb
+++ b/db/migrate/20190912005931_add_priority_to_person.rb
@@ -1,0 +1,5 @@
+class AddPriorityToPerson < ActiveRecord::Migration[5.2]
+  def change
+    add_column :people, :priority, :integer
+  end
+end


### PR DESCRIPTION
Created a database migration to add a priority column to person model and a priority field to _ASPC Senators and Staff_ page in Active Admin. Sorted senators and staff in static controller according to priority column.