### PR TITLE
Enable HTML editing on custom pages and add bulma-accordion

### DIFF
--- a/app/assets/javascripts/active_admin.js
+++ b/app/assets/javascripts/active_admin.js
@@ -1,4 +1,6 @@
 //= require active_admin/base
 
-//= require froala_editor.pkgd.min.js
-//= require plugins/image.min.js
+//= require froala-editor/js/froala_editor.pkgd.min.js
+//= require froala-editor/js/plugins/image.min.js
+//= require codemirror/lib/codemirror.js
+//= require codemirror/mode/xml/xml.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -28,9 +28,11 @@
 
 //= require slick-carousel/slick/slick.js
 
-//= require froala.js
+//= require froala-editor/js/froala_editor.pkgd.min.js
+//= require froala-editor/js/plugins/image.min.js
 //= require codemirror/lib/codemirror.js
 //= require codemirror/mode/xml/xml.js
+
 
 // Page specific javascript here
 //= require events.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -29,6 +29,8 @@
 //= require slick-carousel/slick/slick.js
 
 //= require froala.js
+//= require codemirror/lib/codemirror.js
+//= require codemirror/mode/xml/xml.js
 
 // Page specific javascript here
 //= require events.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,6 +23,7 @@
 
 //= require weekcalendar-2.0/jquery.weekcalendar.js
 
+//= require bulma-accordion/dist/js/bulma-accordion.js
 //= require bulma-calendar/dist/js/bulma-calendar.js
 
 //= require slick-carousel/slick/slick.js

--- a/app/assets/javascripts/static.js
+++ b/app/assets/javascripts/static.js
@@ -6,7 +6,10 @@
 
 document.addEventListener('DOMContentLoaded', function () {
 
-    // Modals
+	// attach bulma-accordion objects to accordions
+	var accordions = bulmaAccordion.attach();
+	
+	// Modals
     var rootEl = document.documentElement;
     var $modals = getAll('.modal');
     var $modalButtons = getAll('.modal-open');

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -13,9 +13,10 @@
 @import "active_admin/base";
 
 /* Froala WYSIWYG styles */
-@import "froala_editor.min";
-@import "froala_style.min";
-@import "plugins/image.min.css";
+@import "froala-editor/css/froala_editor.pkgd.min.css";
+@import "froala-editor/css/froala_style.min.css";
+@import "froala-editor/css/plugins/image.min.css";
+@import "codemirror/lib/codemirror.css";
 
 /* Font Awesome */
 @import "font-awesome";

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,6 +15,7 @@
  *=
  *= require font-awesome
  *= require bulma/css/bulma.sass
+ *= require bulma-accordion/dist/css/bulma-accordion.min.css
  *= require bulma-calendar/dist/css/bulma-calendar.min.css
  *= require bulma-checkradio/dist/css/bulma-checkradio.min.css
  *= require megamenu.scss

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -24,6 +24,7 @@
  *= require slick-carousel/slick/slick-theme.css
  *
  *= require froala.scss
+ *= require codemirror/lib/codemirror.css
  *
  * Sass helpers file
  *= require helpers.scss

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -23,8 +23,11 @@
  *= require slick-carousel/slick/slick.css
  *= require slick-carousel/slick/slick-theme.css
  *
- *= require froala.scss
+ *= require froala-editor/css/froala_editor.pkgd.min.css
+ *= require froala-editor/css/froala_style.min.css
+ *= require froala-editor/css/plugins/image.min.css
  *= require codemirror/lib/codemirror.css
+ *
  *
  * Sass helpers file
  *= require helpers.scss

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -26,7 +26,10 @@ class StaticController < ApplicationController
     @page[:last_modified_by] = current_user[:id]
     @page[:published] = false
 
-    @page.save
+	@page.save
+	
+	# stopgap to force Rails to respond to the POST request and trigger Froala's save.after event
+	render :json => {}
   end
 
   # Approve changes: copy pending_copy to approved_copy

--- a/app/views/admin/statics/_static_page_content_editor.html.erb
+++ b/app/views/admin/statics/_static_page_content_editor.html.erb
@@ -6,7 +6,7 @@
   </div>
   <br/>
 
-  <textarea id="editor"></textarea>
+  <div id="editor"></div>
 
   <br />
   <%= link_to "Save Content", {}, :remote => true, :id => "saveButton", :class => "button" %>
@@ -19,10 +19,10 @@
 <script type="text/javascript">
     $(function() {
         $("#saveSpinner").hide();
-        $("#saveComplete").hide();
-
-        $("#editor").froalaEditor({
-            // License Key
+		$("#saveComplete").hide();
+		
+		var editor = new FroalaEditor('#editor', {
+			// License Key
             key: "<%= Rails.application.credentials[:froala_license_keys][:production] %>",
 
             // Set the save param.
@@ -46,68 +46,72 @@
             fileUploadURL: "<%= static_page_upload_file_path %>",
 
             // Hide character counter
-            charCounterCount: false
-        });
+            charCounterCount: false,
 
-        $("#editor").on("froalaEditor.contentChanged", function(e, editor) {
-            $("#saveComplete").hide();
-        });
+			// Event handlers
+			events: {
+				"contentChanged": function(e, editor) {
+            		$("#saveComplete").hide();
+				},
 
-        $("#editor").on("froalaEditor.save.before", function(e, editor) {
-            $("#saveSpinner").show();
-            $("#saveComplete").hide();
-        });
+				"save.before": function(e, editor) {
+					$("#saveSpinner").show();
+            		$("#saveComplete").hide();
+					console.log("save.before");
+				},
 
-        $("#editor").on("froalaEditor.save.after", function(e, editor, response) {
-            $("#saveSpinner").hide();
-            $("#saveComplete").show();
-            console.log("save.after");
-        });
+				"save.after": function(e, editor, response) {
+					$("#saveSpinner").hide();
+					$("#saveComplete").show();
+					console.log("save.after");
+				},
 
-        $("#editor").on("froalaEditor.image.error", function(e, editor, error) {
-            var popup = editor.popups.get('image.insert');
-            var layer = popup.find('.fr-image-progress-bar-layer');
-            layer.find('h3').text('Image size must be less than 1 MB. Please resize the photo and try again.');
-        });
+				"image.error": function(e, editor, error) {
+					var popup = editor.popups.get('image.insert');
+					var layer = popup.find('.fr-image-progress-bar-layer');
+					layer.find('h3').text('Image size must be less than 1 MB. Please resize the photo and try again.');
+				},
 
-        $("#editor").on('froalaEditor.image.removed', function (e, editor, img) {
-            $.ajax({
-                // Request method.
-                method: "POST",
+				"image.removed": function(e, editor, img) {
+					$.ajax({
+						// Request method.
+						method: "POST",
 
-                // Request URL.
-                url: "<%= static_page_delete_image_path %>",
+						// Request URL.
+						url: "<%= static_page_delete_image_path %>",
 
-                // Request params.
-                data: {
-                    src: img.attr('src')
-                }
-            });
-        });
+						// Request params.
+						data: {
+							src: img.attr('src')
+						}
+					});
+				},
 
-        $("#editor").on('froalaEditor.file.unlink', function (e, editor, link) {
-            $.ajax({
-                // Request method.
-                method: "POST",
+				"file.unlink": function(e, editor, link) {
+					$.ajax({
+						// Request method.
+						method: "POST",
 
-                // Request URL.
-                url: "<%= static_page_delete_file_path %>",
+						// Request URL.
+						url: "<%= static_page_delete_file_path %>",
 
-                // Request params.
-                data: {
-                    src: link.href
-                }
-            });
-        });
+						// Request params.
+						data: {
+							src: link.href
+						}
+					});
+				}
+			}
+		});
 
         // Load the existing preview
-        let content = "<%= page.pending_content %>"
-        decodedContent = $("<textarea></textarea>").html(content).text();   // ampersand-decoding
+        // let content = "<%= page.pending_content %>"
+        // decodedContent = $("<textarea></textarea>").html(content).text();   // ampersand-decoding
 
-        $("#editor").froalaEditor("html.set", decodedContent);
-    });
+		// editor.html.set(decodedContent);
 
-    $("#saveButton").click(function() {
-        $("#editor").froalaEditor("save.save");
+		$("#saveButton").click(function() {
+			editor.save.save();
+		});
     });
 </script>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_28_164415) do
+ActiveRecord::Schema.define(version: 2019_09_12_005931) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 2019_08_28_164415) do
     t.string "details_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "priority"
   end
 
   create_table "course_meeting_details", force: :cascade do |t|
@@ -262,6 +263,7 @@ ActiveRecord::Schema.define(version: 2019_08_28_164415) do
     t.text "biography"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "priority"
   end
 
   create_table "sessions", force: :cascade do |t|

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "bulma-accordion": "^2.0.1",
     "bulma-calendar": "^4.0.2",
     "bulma-checkradio": "^2.1.0",
+    "codemirror": "^5.48.4",
     "slick-carousel": "^1.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "bulma-calendar": "^4.0.2",
     "bulma-checkradio": "^2.1.0",
     "codemirror": "^5.48.4",
+    "froala-editor": "^3.0.5-rc.1",
     "slick-carousel": "^1.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "dependencies": {
     "bulma": "^0.7.1",
+    "bulma-accordion": "^2.0.1",
     "bulma-calendar": "^4.0.2",
     "bulma-checkradio": "^2.1.0",
     "slick-carousel": "^1.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+bulma-accordion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/bulma-accordion/-/bulma-accordion-2.0.1.tgz#5493c51dd7c5926ae47115da3efe858cfb115474"
+  integrity sha512-qqLN67Y60c0adHAVvQmJTr6rhg0FWUCWbswFaW/3+offjc6ujqrUoIdlzX1avni4d/aJEl7j9PckfRGmIJcxxQ==
+
 bulma-calendar@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/bulma-calendar/-/bulma-calendar-4.0.2.tgz#a620811f5002bbb76e408788c03050ff6926cb67"

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,6 +29,11 @@ codemirror@^5.48.4:
   resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.48.4.tgz#4210fbe92be79a88f0eea348fab3ae78da85ce47"
   integrity sha512-pUhZXDQ6qXSpWdwlgAwHEkd4imA0kf83hINmUEzJpmG80T/XLtDDEzZo8f6PQLuRCcUQhmzqqIo3ZPTRaWByRA==
 
+froala-editor@^3.0.5-rc.1:
+  version "3.0.5-rc.1"
+  resolved "https://registry.yarnpkg.com/froala-editor/-/froala-editor-3.0.5-rc.1.tgz#205b4f4ff26e1852f3c63afaaf2ab118432f9460"
+  integrity sha512-9d4ohl/UpntSuBerxjpcWPrt+4dWHL5PmjqbWVjIdvSkKvsDYSR/f6zC7s95ekcme/K7J17Hl/OzNFnraxVyIQ==
+
 moment@^2.22.2:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,6 +24,11 @@ bulma@^0.7.1:
   resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.7.1.tgz#73c2e3b2930c90cc272029cbd19918b493fca486"
   integrity sha512-wRSO2LXB+qI9Pyz2id+uZr4quz5aftSN7Ay1ysr1+krzVp3utD+Ci4CeKuZdrYGc800t65b7heXBL6qw2Wo/lQ==
 
+codemirror@^5.48.4:
+  version "5.48.4"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.48.4.tgz#4210fbe92be79a88f0eea348fab3ae78da85ce47"
+  integrity sha512-pUhZXDQ6qXSpWdwlgAwHEkd4imA0kf83hINmUEzJpmG80T/XLtDDEzZo8f6PQLuRCcUQhmzqqIo3ZPTRaWByRA==
+
 moment@^2.22.2:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"


### PR DESCRIPTION
Turns out Froala Editor depends on integration with codemirror to enable HTML editing. The Rails Froala gem wasn't communicating with codemirror, so I had to switch everything over to the NPM package instead. Static page editing is still working as far as I can tell.