### PR TITLE
Fix/filter course planner

### DIFF
--- a/app/assets/stylesheets/courses.scss
+++ b/app/assets/stylesheets/courses.scss
@@ -491,11 +491,14 @@ select {
     }
 
     .meets-on, .avoid-schedule {
+      display: flex;
+      flex-shrink: 1;
+
       .is-checkradio[type="checkbox"].is-block + label,
       .is-checkradio[type="radio"].is-block + label {
         background: #dbdbdb;
         color: #363636;
-        opacity: 0.5;
+        opacity: 0.5;    
       }
 
       .is-checkradio[type="checkbox"]:checked + label,

--- a/app/views/courses/partials/_course_search_form.html.erb
+++ b/app/views/courses/partials/_course_search_form.html.erb
@@ -57,7 +57,7 @@
         <div class="field is-grouped checkboxes">
            <div class="control avoid-schedule">
               <input class="is-checkradio is-block is-info" id="avoid_schedule" type="checkbox" name="avoid_schedule">
-              <label for="avoid_schedule">Avoid Schedule</label>
+              <label for="avoid_schedule">Hide courses conflicting with schedule</label>
           </div>
         </div>
       </div>
@@ -95,6 +95,7 @@
         <div class="control">
           <%= f.time_select :end_time, {ampm: true, start_hour: 8, end_hour: 23, ignore_date: true, prompt: true, prompt: {hour: "End"}} %>
         </div>
+      </div>
       
       <div class="field">
         <label class="label">Taught by</label>

--- a/app/views/courses/partials/_course_search_form.html.erb
+++ b/app/views/courses/partials/_course_search_form.html.erb
@@ -53,6 +53,15 @@
         </div>
       </div>
       <div class="field">
+        <label class="label">Filter</label>
+        <div class="field is-grouped checkboxes">
+           <div class="control avoid-schedule">
+              <input class="is-checkradio is-block is-info" id="avoid_schedule" type="checkbox" name="avoid_schedule">
+              <label for="avoid_schedule">Avoid Schedule</label>
+          </div>
+        </div>
+      </div>
+      <div class="field">
         <label class="label">School</label>
         <div class="field is-grouped checkboxes colleges">
           <div class="control">
@@ -77,12 +86,6 @@
           </div>
         </div>
       </div>
-      <div class="field">
-        <div class="control avoid-schedule">
-              <input class="is-checkradio is-block is-info" id="avoid_schedule" type="checkbox" name="avoid_schedule">
-              <label for="avoid_schedule">Avoid Schedule</label>
-          </div>
-        </div>
 
       <div class="field">
         <label class="label">Time</label>


### PR DESCRIPTION
<img width="324" alt="Screen Shot 2022-03-06 at 5 14 21 PM" src="https://user-images.githubusercontent.com/69527370/156951656-49ef893a-2437-4d89-b83e-afb8a4b93d7e.png">

Add new filter section 
Also fixed the div for Time filter which makes the spacing better