### PR TITLE
fix course description

### DIFF
--- a/app/views/courses/partials/_course_list.html.erb
+++ b/app/views/courses/partials/_course_list.html.erb
@@ -88,7 +88,9 @@
             </div>
             <div class="columns">
               <div class="column">
-                c
+                <p>
+                  <%= raw section.description %>
+                </p>
               </div>
             </div>
             <div class="columns">


### PR DESCRIPTION
Accidentally deleted a line for the description when working on the modal feature for course planner. Sorry for not noticing this earlier. 
<img width="460" alt="Screen Shot 2022-03-28 at 1 01 05 PM" src="https://user-images.githubusercontent.com/69527370/160477570-18de1e15-bb39-4161-a4c2-9724adec0e77.png">
.