### PR TITLE
remove fall 2022 elections banner

### DIFF
--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -42,13 +42,6 @@
 <div class="columns margin-bottom-3">
   <div class="column is-full">
   <aside class="box">
-    <h4 class="title is-4">Fall 2022 Elections</h4>
-    <p class="margin-bottom-2">
-    Vote now for First Year Class President, North Campus Representative and South Campus Representative
-    </p>
-    <a class="button is-info is-outlined" href="https://pomonastudents.org/vote" target="_blank">Vote Now</a>
-  </aside>
-  <aside class="box">
     <h4 class="title is-4">2022 Fall Funding Request Forms</h4>
     <p class="margin-bottom-2">
     Request funds allocated for student and club events from ASPC.


### PR DESCRIPTION
Remove fall 2022 elections banner from Homepage

**Testing**:
Before:
![Screen Shot 2022-09-19 at 9 55 01 AM](https://user-images.githubusercontent.com/69527053/191072300-231c7154-7b94-4566-a086-0a4fbc2cda40.png)

After:
![Screen Shot 2022-09-19 at 9 55 26 AM](https://user-images.githubusercontent.com/69527053/191072285-54c74b1d-3299-4929-a7d9-e8f0eb4398fb.png)
