### PR TITLE
swap events with funding on home page

### DIFF
--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -35,22 +35,6 @@
     </div>
 <% end %>
 
-<div class="margin-bottom-2 home-heading">
-  <h3 class="title is-3">Latest From ASPC</h3>
-</div>
-
-<div class="columns margin-bottom-3">
-  <div class="column is-full">
-  <aside class="box">
-    <h4 class="title is-4">2022 Fall Funding Request Forms</h4>
-    <p class="margin-bottom-2">
-    Request funds allocated for student and club events from ASPC.
-    </p>
-    <%= link_to "Click Here", static_path("funding-request"), :class => "button is-info is-outlined" %>
-  </aside>
-  </div>
-</div>
-
 <!-- <div class="columns margin-bottom-3">
   <div class="column is-full">
     <aside class="box">
@@ -160,6 +144,22 @@
       </div>
     </div>
   <% end %>
+</div>
+
+<div class="margin-bottom-2 home-heading">
+  <h3 class="title is-3">Latest From ASPC</h3>
+</div>
+
+<div class="columns margin-bottom-3">
+  <div class="column is-full">
+  <aside class="box">
+    <h4 class="title is-4">2022 Fall Funding Request Forms</h4>
+    <p class="margin-bottom-2">
+    Request funds allocated for student and club events from ASPC.
+    </p>
+    <%= link_to "Click Here", static_path("funding-request"), :class => "button is-info is-outlined" %>
+  </aside>
+  </div>
 </div>
 
 <div class="margin-bottom-3 home-heading">


### PR DESCRIPTION
### Description:
Swap location of _Upcoming Events_ with _Latest From ASPC Fall Funding Requests_ to draw more attention to the events featured on the site.

### Testing:
**Before:**
<img width="1440" alt="Screen Shot 2022-10-10 at 1 34 33 PM" src="https://user-images.githubusercontent.com/69527053/194949003-99fbdb13-0784-477c-b80c-13f6a9ebfa1e.png">

**After (tested locally with no event data):**
<img width="1440" alt="Screen Shot 2022-10-10 at 1 35 29 PM" src="https://user-images.githubusercontent.com/69527053/194948993-5201ae68-95b2-49a5-83c0-9aacec513ecf.png">
