### PR TITLE
add photo functionality and admin to sdg page

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -92,6 +92,10 @@ class StaticController < ApplicationController
     @staff = Person.priority_order.staff.order("id ASC")
   end
 
+  def sdg
+    @sdg = Person.priority_order.staff.order("id ASC")
+  end
+
   def housing_platform
   end
 

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -93,7 +93,7 @@ class StaticController < ApplicationController
   end
 
   def sdg
-    @sdg = Person.priority_order.staff.order("id ASC")
+    @sdg = Person.priority_order.sdg.order("id ASC")
   end
 
   def housing_platform

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,7 +1,7 @@
 require "mini_magick"
 
 class Person < ApplicationRecord
-  enum role: [:senator, :staff, :board]
+  enum role: [:senator, :staff, :board, :sdg]
   scope :priority_order, -> {order(priority: :asc)}
   has_one_attached :image
 

--- a/app/views/components/_application_footer.html.erb
+++ b/app/views/components/_application_footer.html.erb
@@ -12,7 +12,7 @@
         </a>
       </div>
       <div class="column text has-text-right-desktop">
-        <p>Created by <%= link_to "ASPC Software Development Group", static_path(page_name: "software") %>.</p>
+        <p>Created by <%= link_to "ASPC Software Development Group", sdg_path %>.</p>
       </div>
     </div>
   </div>

--- a/app/views/components/_application_header.html.erb
+++ b/app/views/components/_application_header.html.erb
@@ -85,7 +85,7 @@
                   <%= link_to "Staff", staff_path, :class => "navbar-item" %>
                 </div>
                 <div class="navbar-content">
-                  <%= link_to "Software Development Group", static_path(page_name: "software"), :class => "navbar-item" %>
+                  <%= link_to "Software Development Group", sdg_path, :class => "navbar-item" %>
                 </div>
               </div>
               <div class="column">

--- a/app/views/static/sdg.html.erb
+++ b/app/views/static/sdg.html.erb
@@ -1,56 +1,67 @@
 <% content_for :header do %>
-    <%= render 'components/page_header', :title => "Software Development Group" %>
+    <%= render 'components/page_header', :title => "Software Development Group", :subtitle => "2022-2023"%>
 <% end %>
 
-<% if @group %>
-  <% @sdg.in_groups_of(3, false).each do |group| %>
-      <div class="columns">
-        <% group.each do |sdg| %>
-          <div class="column is-4">
-            <div class="card">
-              <div class="card-image">
-                <figure class="image senator-image">
-                  <%= avatar_photo sdg %>
-                </figure>
-              </div>
-              <div class="card-content">
-                <div class="media">
-                  <div class="media-content">
-                    <h5 class="title is-5 margin-bottom-2">
-                      <%= sdg.name %></h5>
-                    <h6 class="subtitle is-6 has-text-weight-semibold margin-bottom-0">
-                      <%= sdg.position %></h6>
-                    <h6 class="subtitle is-6 margin-bottom-1">
-                      <%= sdg.email %></h6>
-                    <% if sdg.biography.empty? %>
-                      <span class="button is-static">Biography</span>
-                    <% else %>
-                      <a class="button is-info is-outlined modal-open"
-                        data-target="<%= sdg.name.parameterize %>-biography">Biography</a>
-                    <% end %>
-                  </div>
+<div class="content">
+    <h2>Who We Are</h2>
+    <p>We are a team of students hoping to improve the daily lives of other students. The Software Development Group is part of ASPC’s staff and works closely with Senate, fellow staff members, and affiliated 5C clubs and organizations. Our goal is to provide useful services, tools, and resources to the students of Pomona College and the 5C community. In addition to creating the site you are now visiting, we maintain the central ASPC server, coordinate the online voting system with ASPC, and provide web hosting for official ASPC clubs.</p>
+    <h2>How You Can Contribute
+    </h2><p>We aim to build things that benefit the lives of the 5,000+ students who attend the Claremont Colleges. As students ourselves, we understand the importance of community input and realize that there is always room for improvement. If you have any ideas for the website, please feel free to reach out to us!</p>
+    <p>In addition, if you want to contribute to the website or start hacking on your own, check out our <a href="https://github.com/aspc/aspc-website">GitHub</a>.</p>
+    <h2>Our Team</h2>
+</div>
+
+<% @sdg.in_groups_of(3, false).each do |group| %>
+    <div class="columns">
+      <% group.each do |sdg| %>
+        <div class="column is-4">
+          <div class="card">
+            <div class="card-image">
+              <figure class="image senator-image">
+                <%= avatar_photo sdg %>
+              </figure>
+            </div>
+            <div class="card-content">
+              <div class="media">
+                <div class="media-content">
+                  <h5 class="title is-5 margin-bottom-2">
+                    <%= sdg.name %></h5>
+                  <h6 class="subtitle is-6 has-text-weight-semibold margin-bottom-0">
+                    <%= sdg.position %></h6>
+                  <h6 class="subtitle is-6 margin-bottom-1">
+                    <%= sdg.email %></h6>
+                  <% if sdg.biography.empty? %>
+                    <span class="button is-static">Biography</span>
+                  <% else %>
+                    <a class="button is-info is-outlined modal-open"
+                      data-target="<%= sdg.name.parameterize %>-biography">Biography</a>
+                  <% end %>
                 </div>
               </div>
             </div>
           </div>
+        </div>
 
-          <% if not sdg.biography.empty? %>
-            <div class="modal" id="<%= sdg.name.parameterize %>-biography">
-              <div class="modal-background"></div>
-              <div class="modal-content">
-                <div class="modal-card">
-                  <div class="box">
-                    <h4 class="title is-4">
-                      <%= sdg.name %></h4>
-                    <p>
-                      <%= sdg.biography %></p>
-                  </div>
+        <% if not sdg.biography.empty? %>
+          <div class="modal" id="<%= sdg.name.parameterize %>-biography">
+            <div class="modal-background"></div>
+            <div class="modal-content">
+              <div class="modal-card">
+                <div class="box">
+                  <h4 class="title is-4">
+                    <%= sdg.name %></h4>
+                  <p>
+                    <%= sdg.biography %></p>
                 </div>
               </div>
-              <button class="modal-close is-large" aria-label="close"></button>
             </div>
-          <% end %>
+            <button class="modal-close is-large" aria-label="close"></button>
+          </div>
         <% end %>
-      </div>
-  <% end %>
+      <% end %>
+    </div>
 <% end %>
+
+<div class="content">
+<h2>Contact Us</h2><p>For administrative inquiries or product suggestions: <a href="mailto:product@aspc.pomona.edu"></a><a href="mailto:product@aspc.pomona.edu">product@aspc.pomona.edu</a></p>
+</div>

--- a/app/views/static/sdg.html.erb
+++ b/app/views/static/sdg.html.erb
@@ -1,0 +1,56 @@
+<% content_for :header do %>
+    <%= render 'components/page_header', :title => "Software Development Group" %>
+<% end %>
+
+<% if @group %>
+  <% @sdg.in_groups_of(3, false).each do |group| %>
+      <div class="columns">
+        <% group.each do |sdg| %>
+          <div class="column is-4">
+            <div class="card">
+              <div class="card-image">
+                <figure class="image senator-image">
+                  <%= avatar_photo sdg %>
+                </figure>
+              </div>
+              <div class="card-content">
+                <div class="media">
+                  <div class="media-content">
+                    <h5 class="title is-5 margin-bottom-2">
+                      <%= sdg.name %></h5>
+                    <h6 class="subtitle is-6 has-text-weight-semibold margin-bottom-0">
+                      <%= sdg.position %></h6>
+                    <h6 class="subtitle is-6 margin-bottom-1">
+                      <%= sdg.email %></h6>
+                    <% if sdg.biography.empty? %>
+                      <span class="button is-static">Biography</span>
+                    <% else %>
+                      <a class="button is-info is-outlined modal-open"
+                        data-target="<%= sdg.name.parameterize %>-biography">Biography</a>
+                    <% end %>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <% if not sdg.biography.empty? %>
+            <div class="modal" id="<%= sdg.name.parameterize %>-biography">
+              <div class="modal-background"></div>
+              <div class="modal-content">
+                <div class="modal-card">
+                  <div class="box">
+                    <h4 class="title is-4">
+                      <%= sdg.name %></h4>
+                    <p>
+                      <%= sdg.biography %></p>
+                  </div>
+                </div>
+              </div>
+              <button class="modal-close is-large" aria-label="close"></button>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,7 @@ Rails.application.routes.draw do
     get 'index' => :index
     get 'senators' => :senators
     get 'staff' => :staff
+    get 'sdg' => :sdg
     get 'housing-platform' => :housing_platform
     get 'career-opportunities' => :career_opportunities
     


### PR DESCRIPTION
### Description

Add photos and bios to Software Development Group page. Deprecate old page. Link to new page across site. 

### Testing

##### Before

![before](https://user-images.githubusercontent.com/74080246/200695313-c6840590-175e-4aca-8162-894e8570afa4.gif)

##### After
https://user-images.githubusercontent.com/74080246/200695855-c38d7cf6-9555-4d37-a241-50a5c18758e3.mov

##### Admin portal
add images and bio (created new role called sdg):
<img width="1499" alt="Screen Shot 2022-11-08 at 3 07 50 PM" src="https://user-images.githubusercontent.com/74080246/200695401-16cc4d47-207c-460d-ad9d-991c6b1df4a0.png">

#### Links across site

https://user-images.githubusercontent.com/74080246/200696872-9ba4e073-1da8-4d95-9488-50376654ead8.mov