### PR TITLE
Added Spring23 calendar export functionality

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -48,6 +48,10 @@ class CoursesController < ApplicationController
       term_start = DateTime.new(2021, 1, 25, 8, 10, 0)
       term_end = DateTime.new(2021, 5, 6, 22, 0, 0)
     else
+    when "2023;SP"
+      term_start = DateTime.new(2023, 1, 17, 8, 10, 0)
+      term_end = DateTime.new(2023, 5, 12, 22, 0, 0)
+    else
       return redirect_to course_planner_path # This is temporary and MUST be made into something more permanent than hardcoding
     end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -47,10 +47,12 @@ class CoursesController < ApplicationController
     when "2021;SP"
       term_start = DateTime.new(2021, 1, 25, 8, 10, 0)
       term_end = DateTime.new(2021, 5, 6, 22, 0, 0)
-    else
+    when "2022;FA"
+      term_start = DateTime.new(2022, 8, 29, 8, 10, 0)
+      term_end = DateTime.new(2022, 12, 7, 22, 0, 0)
     when "2023;SP"
       term_start = DateTime.new(2023, 1, 17, 8, 10, 0)
-      term_end = DateTime.new(2023, 5, 12, 22, 0, 0)
+      term_end = DateTime.new(2023, 5, 3, 22, 0, 0)
     else
       return redirect_to course_planner_path # This is temporary and MUST be made into something more permanent than hardcoding
     end


### PR DESCRIPTION
Previously, since spring23 was not included in possible academic terms, export calendar function would return back to planner. 