### PR TITLE
Remove "Jboard" dropdown link on the home page's navigation bar.

### DIFF
--- a/app/views/components/_application_header.html.erb
+++ b/app/views/components/_application_header.html.erb
@@ -122,9 +122,6 @@
             <%= link_to "Housing", :housing_rooms, :class => "navbar-item" %>
           </div>
           <div class="navbar-content">
-            <%= link_to "JBoard", static_path(page_name: "jboard"), :class => "navbar-item" %>
-          </div>
-          <div class="navbar-content">
             <!-- Menus -->
             <%= link_to "Menus", :menus, :class => "navbar-item" %>
           </div>


### PR DESCRIPTION
Removed "Jboard" dropdown link on the home page's navigation bar.

Before:
<img width="1231" alt="Screen Shot 2023-01-31 at 5 21 31 PM" src="https://user-images.githubusercontent.com/79251745/215921787-fcd2b051-7ffb-48f9-8764-0f35b97e1da5.png">

After:
<img width="1244" alt="Screen Shot 2023-01-31 at 5 21 53 PM" src="https://user-images.githubusercontent.com/79251745/215921823-3c3690f7-1c08-4e8f-9ec0-da8237c80d6b.png">
