### PR TITLE
Change home page's section stylings

### DIFF
--- a/app/assets/stylesheets/overrides.scss
+++ b/app/assets/stylesheets/overrides.scss
@@ -30,18 +30,19 @@
  */
  
 .box {
+  box-shadow: none;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
 }
 
-.main-box .box {
-  box-shadow: -10px 10px 0px -1px #2c3e50;
-  background: #dfeffa;
-}
+// .main-box .box {
+//   box-shadow: -10px 10px 0px -1px #2c3e50;
+//   background: #dfeffa;
+// }
 
-.upcoming-events-header-container {
-  text-align: center;
-}
+// .upcoming-events-header-container {
+//   text-align: center;
+// }
 
 .ta-center {
   text-align: center;

--- a/app/assets/stylesheets/overrides.scss
+++ b/app/assets/stylesheets/overrides.scss
@@ -35,14 +35,16 @@
   border-radius: 4px;
 }
 
-// .main-box .box {
-//   box-shadow: -10px 10px 0px -1px #2c3e50;
-//   background: #dfeffa;
-// }
+.column.landing-page-slideshow-column {
+  width: 50% !important
+}
 
-// .upcoming-events-header-container {
-//   text-align: center;
-// }
+@media screen and (max-width: 768px) {
+  .column.landing-page-slideshow-column {
+    width: 100% !important
+  }
+}
+
 
 .ta-center {
   text-align: center;

--- a/app/assets/stylesheets/overrides.scss
+++ b/app/assets/stylesheets/overrides.scss
@@ -90,23 +90,33 @@
   color: #fff;
 }
 
-.slick-prev {
-  left: 0.5rem;
+
+/*
+ * Slideshow landing page
+ */
+
+.main-box {
+  padding-left: 3rem !important;
+  padding-right: 3rem !important;
+}
+
+.main-box .slick-prev {
+  left: -2.6rem !important;  
   top: 60%;
   height: 40px;
   width: 40px
 }
 
-.slick-next {
-  right: 0.5rem;
+.main-box .slick-next {
+  right: -2.6rem !important;
   top: 60%;
   height: 40px;
   width: 40px
 }
 
-.slick-prev:before {
-  color: black;
+.main-box .slick-prev:before {
+  color: #717171;
 }
-.slick-next:before {
-  color: black;
+.main-box .slick-next:before {
+  color: #717171;
 }

--- a/app/assets/stylesheets/overrides.scss
+++ b/app/assets/stylesheets/overrides.scss
@@ -28,11 +28,26 @@
 /*
  * Boxes
  */
+ 
 .box {
-  box-shadow: none;
   border: 1px solid #dbdbdb;
   border-radius: 4px;
 }
+
+.main-box .box {
+  box-shadow: -10px 10px 0px -1px #2c3e50;
+  background: #dfeffa;
+}
+
+.upcoming-events-header-container {
+  text-align: center;
+}
+
+.ta-center {
+  text-align: center;
+}
+
+// }
 
 /*
  * Calendar

--- a/app/assets/stylesheets/overrides.scss
+++ b/app/assets/stylesheets/overrides.scss
@@ -89,3 +89,24 @@
   background-color: #209cee;
   color: #fff;
 }
+
+.slick-prev {
+  left: 0.5rem;
+  top: 60%;
+  height: 40px;
+  width: 40px
+}
+
+.slick-next {
+  right: 0.5rem;
+  top: 60%;
+  height: 40px;
+  width: 40px
+}
+
+.slick-prev:before {
+  color: black;
+}
+.slick-next:before {
+  color: black;
+}

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -52,11 +52,9 @@
 
 <div class="columns">
   <div class="column landing-page-slideshow-column">
-      <div class="margin-bottom-3 home-heading upcoming-events-header-container columns">
+      <div class="home-heading upcoming-events-header-container columns">
         <div class="buttons column">
         <h3 class="title is-3 upcoming-events-header">Upcoming Events</h3>
-          <a class="button is-outlined is-info" href="/events">See more events</a>
-          <a class="button is-outlined is-info" href="https://pomona.campuslabs.com/engage/">Submit an event</a>
         </div>
       </div>
 
@@ -75,7 +73,6 @@
           } do %>
             <% @events.each do |item| %>
               <div class="container">
-                <div class="box">
                   <div class="columns events-slide">
                     <% campus_background_color_class = bg_color_class(item)
                     %>
@@ -94,7 +91,6 @@
                       </p>
                     </div>
                   </div>
-                </div>
               </div>
             <% end %>
           <% end %>
@@ -106,6 +102,8 @@
           </div>
         <% end %>
       </div>
+      <a class="button is-outlined is-info" href="/events">See more events</a>
+      <a class="button is-outlined is-info" href="https://pomona.campuslabs.com/engage/">Submit an event</a>
     </div>
   </div>
 

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -60,7 +60,7 @@
 
     <!-- Events slideshow for desktop screens -->
     <!-- Events slideshow for mobile screens -->
-    <div class="box">
+    <div class="box main-box">
       <div class="">
         <% if @events.length > 0 %>
           <%= render 'components/slideshow', :id => "events-slideshow-mobile", :slideshow_options => {

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -51,7 +51,7 @@
 </div> -->
 
 <div class="columns">
-  <div class="column">
+  <div class="column landing-page-slideshow-column">
       <div class="margin-bottom-3 home-heading upcoming-events-header-container columns">
         <div class="buttons column">
         <h3 class="title is-3 upcoming-events-header">Upcoming Events</h3>
@@ -61,54 +61,9 @@
       </div>
 
     <!-- Events slideshow for desktop screens -->
-      <div class="is-hidden-mobile">
-        <% if @events.length > 0 %>
-          <%= render 'components/slideshow', :id => "events-slideshow-desktop", :slideshow_options => {
-              :autoplay => true,
-              :arrows => true,
-              :dots => true,
-              :useTransform => true,
-              :easing => 'swing',
-              :fade => true
-          } do %>
-            <% @events.each_slice(3) do |list| %>
-              <div class="container events-slide">
-                <div class="columns">
-                  <% list.each do |item| %>
-                    <% campus_background_color_class = bg_color_class(item)
-                    %>
-                    <div class="column is-4 event">
-                      <div class="box" style="height: 100%; display: inline-block;"> 
-                        <div class="event-info <%= campus_background_color_class %>">
-                          <p class="event-date-time"><%= item.start.strftime("%B %e") %>
-                            , <%= item.start.strftime("%l:%M%P") %>
-                            -<%= item.end.strftime("%l:%M%P") %></p>
-                          <p class="event-location"><%= item.location %><br></p>
-                        </div>
-                        <h4 class="title is-4">
-                          <a href="<%= url_for(item) %>"><%= item.name %></a>
-                        </h4>
-                        <p class="event-host is-4 ">
-                          <%= item.host %>
-                        </p>
-                      </div>
-                    </div>
-                  <% end %>
-                </div>
-              </div>
-            <% end %>
-          <% end %>
-        <% else %>
-          <div class="columns margin-bottom-3">
-            <div class="column">
-              <p>There are no events available.</p>
-            </div>
-          </div>
-        <% end %>
-      </div>
-
     <!-- Events slideshow for mobile screens -->
-      <div class="is-hidden-tablet is-hidden-desktop">
+    <div class="box">
+      <div class="">
         <% if @events.length > 0 %>
           <%= render 'components/slideshow', :id => "events-slideshow-mobile", :slideshow_options => {
               :autoplay => true,
@@ -120,22 +75,24 @@
           } do %>
             <% @events.each do |item| %>
               <div class="container">
-                <div class="columns events-slide">
-                  <% campus_background_color_class = bg_color_class(item)
-                  %>
-                  <div class="column event">
-                    <div class="event-info <%= campus_background_color_class %>">
-                      <p class="event-date-time"><%= item.start.strftime("%B %e") %>
-                        , <%= item.start.strftime("%l:%M%P") %>
-                        -<%= item.end.strftime("%l:%M%P") %></p>
-                      <p class="event-location"><%= item.location %><br></p>
+                <div class="box">
+                  <div class="columns events-slide">
+                    <% campus_background_color_class = bg_color_class(item)
+                    %>
+                    <div class="column event">
+                      <div class="event-info <%= campus_background_color_class %>">
+                        <p class="event-date-time"><%= item.start.strftime("%B %e") %>
+                          , <%= item.start.strftime("%l:%M%P") %>
+                          -<%= item.end.strftime("%l:%M%P") %></p>
+                        <p class="event-location"><%= item.location %><br></p>
+                      </div>
+                      <h4 class="title is-4">
+                        <a href="<%= url_for(item) %>"><%= item.name %></a>
+                      </h4>
+                      <p class="event-host is-4">
+                        <%= item.host %>
+                      </p>
                     </div>
-                    <h4 class="title is-4">
-                      <a href="<%= url_for(item) %>"><%= item.name %></a>
-                    </h4>
-                    <p class="event-host is-4">
-                      <%= item.host %>
-                    </p>
                   </div>
                 </div>
               </div>
@@ -149,6 +106,7 @@
           </div>
         <% end %>
       </div>
+    </div>
   </div>
 
   <div class="column">

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -50,121 +50,137 @@
   </div>
 </div> -->
 
-<div class="margin-bottom-3 home-heading">
-  <h3 class="title is-3">Upcoming Events</h3>
-  <div class="buttons">
-    <a class="button is-outlined is-info" href="/events">See more events</a>
-    <a class="button is-outlined is-info" href="https://pomona.campuslabs.com/engage/">Submit an event</a>
-  </div>
-</div>
-
-<!-- Events slideshow for desktop screens -->
-<div class="is-hidden-mobile">
-  <% if @events.length > 0 %>
-    <%= render 'components/slideshow', :id => "events-slideshow-desktop", :slideshow_options => {
-        :autoplay => true,
-        :arrows => false,
-        :dots => true,
-        :useTransform => true,
-        :easing => 'swing',
-        :fade => true
-    } do %>
-      <% @events.each_slice(3) do |list| %>
-        <div class="container events-slide">
-          <div class="columns">
-            <% list.each do |item| %>
-              <% campus_background_color_class = bg_color_class(item)
-              %>
-              <div class="column is-4 event">
-                <div class="event-info <%= campus_background_color_class %>">
-                  <p class="event-date-time"><%= item.start.strftime("%B %e") %>
-                    , <%= item.start.strftime("%l:%M%P") %>
-                    -<%= item.end.strftime("%l:%M%P") %></p>
-                  <p class="event-location"><%= item.location %><br></p>
-                </div>
-                <h4 class="title is-4">
-                  <a href="<%= url_for(item) %>"><%= item.name %></a>
-                </h4>
-                <p class="event-host is-4 ">
-                  <%= item.host %>
-                </p>
-              </div>
-            <% end %>
-          </div>
-        </div>
-      <% end %>
-    <% end %>
-  <% else %>
-    <div class="columns margin-bottom-3">
-      <div class="column">
-        <p>There are no events available.</p>
+    <div class="margin-bottom-3 home-heading upcoming-events-header-container columns">
+      <div class="buttons ta-center column">
+      <h3 class="title is-3 upcoming-events-header">Upcoming Events</h3>
+        <a class="button is-outlined is-info" href="/events">See more events</a>
+        <a class="button is-outlined is-info" href="https://pomona.campuslabs.com/engage/">Submit an event</a>
       </div>
     </div>
-  <% end %>
-</div>
 
-<!-- Events slideshow for mobile screens -->
-<div class="is-hidden-tablet is-hidden-desktop">
-  <% if @events.length > 0 %>
-    <%= render 'components/slideshow', :id => "events-slideshow-mobile", :slideshow_options => {
-        :autoplay => true,
-        :arrows => false,
-        :dots => true,
-        :useTransform => true,
-        :easing => 'swing',
-        :fade => true
-    } do %>
-      <% @events.each do |item| %>
-        <div class="container">
-          <div class="columns events-slide">
-            <% campus_background_color_class = bg_color_class(item)
-            %>
-            <div class="column event">
-              <div class="event-info <%= campus_background_color_class %>">
-                <p class="event-date-time"><%= item.start.strftime("%B %e") %>
-                  , <%= item.start.strftime("%l:%M%P") %>
-                  -<%= item.end.strftime("%l:%M%P") %></p>
-                <p class="event-location"><%= item.location %><br></p>
+    <!-- Events slideshow for desktop screens -->
+    <div class="is-hidden-mobile">
+      <% if @events.length > 0 %>
+        <%= render 'components/slideshow', :id => "events-slideshow-desktop", :slideshow_options => {
+            :autoplay => true,
+            :arrows => false,
+            :dots => true,
+            :useTransform => true,
+            :easing => 'swing',
+            :fade => true
+        } do %>
+          <% @events.each_slice(3) do |list| %>
+            <div class="container events-slide">
+              <div class="columns">
+                <% list.each do |item| %>
+                  <% campus_background_color_class = bg_color_class(item)
+                  %>
+                  <div class="column box is-4 event">
+                    <div class="event-info <%= campus_background_color_class %>">
+                      <p class="event-date-time"><%= item.start.strftime("%B %e") %>
+                        , <%= item.start.strftime("%l:%M%P") %>
+                        -<%= item.end.strftime("%l:%M%P") %></p>
+                      <p class="event-location"><%= item.location %><br></p>
+                    </div>
+                    <h4 class="title is-4">
+                      <a href="<%= url_for(item) %>"><%= item.name %></a>
+                    </h4>
+                    <p class="event-host is-4 ">
+                      <%= item.host %>
+                    </p>
+                  </div>
+                <% end %>
               </div>
-              <h4 class="title is-4">
-                <a href="<%= url_for(item) %>"><%= item.name %></a>
-              </h4>
-              <p class="event-host is-4">
-                <%= item.host %>
-              </p>
             </div>
+          <% end %>
+        <% end %>
+      <% else %>
+        <div class="columns margin-bottom-3">
+          <div class="column ta-center">
+            <p>There are no events available.</p>
           </div>
         </div>
       <% end %>
-    <% end %>
-  <% else %>
+    </div>
+
+    <!-- Events slideshow for mobile screens -->
+    <div class="is-hidden-tablet is-hidden-desktop">
+      <% if @events.length > 0 %>
+        <%= render 'components/slideshow', :id => "events-slideshow-mobile", :slideshow_options => {
+            :autoplay => true,
+            :arrows => false,
+            :dots => true,
+            :useTransform => true,
+            :easing => 'swing',
+            :fade => true
+        } do %>
+          <% @events.each do |item| %>
+            <div class="container">
+              <div class="columns events-slide">
+                <% campus_background_color_class = bg_color_class(item)
+                %>
+                <div class="column event">
+                  <div class="event-info <%= campus_background_color_class %>">
+                    <p class="event-date-time"><%= item.start.strftime("%B %e") %>
+                      , <%= item.start.strftime("%l:%M%P") %>
+                      -<%= item.end.strftime("%l:%M%P") %></p>
+                    <p class="event-location"><%= item.location %><br></p>
+                  </div>
+                  <h4 class="title is-4">
+                    <a href="<%= url_for(item) %>"><%= item.name %></a>
+                  </h4>
+                  <p class="event-host is-4">
+                    <%= item.host %>
+                  </p>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      <% else %>
+        <div class="columns margin-bottom-3">
+          <div class="column">
+            <p>There are no events available.</p>
+          </div>
+        </div>
+      <% end %>
+    </div>
+
+<div class="columns main-box">
+  <div class="column">
+    <div class="margin-bottom-2 home-heading">
+      <h3 class="title is-3">Latest From ASPC</h3>
+    </div>
+
     <div class="columns margin-bottom-3">
-      <div class="column">
-        <p>There are no events available.</p>
+      <div class="column is-full">
+        <aside class="box">
+          <h4 class="title is-4">Spring 2023 Funding Request Forms</h4>
+          <p class="margin-bottom-2">
+          Request funds allocated for student and club events from ASPC.
+          </p>
+          <%= link_to "Click Here", static_path("funding-request"), :class => "button is-info is-outlined" %>
+        </aside>
       </div>
     </div>
-  <% end %>
-</div>
-
-<div class="margin-bottom-2 home-heading">
-  <h3 class="title is-3">Latest From ASPC</h3>
-</div>
-
-<div class="columns margin-bottom-3">
-  <div class="column is-full">
-  <aside class="box">
-    <h4 class="title is-4">Spring 2023 Funding Request Forms</h4>
-    <p class="margin-bottom-2">
-    Request funds allocated for student and club events from ASPC.
-    </p>
-    <%= link_to "Click Here", static_path("funding-request"), :class => "button is-info is-outlined" %>
-  </aside>
   </div>
-</div>
 
-<div class="margin-bottom-3 home-heading">
-  <h3 class="title is-3">The Student Life</h3>
-  <a class="button is-outlined is-info" href="https://tsl.news" target="_blank">Go to TSL</a>
+  <div class="column ">
+    <div class="margin-bottom-2 home-heading">
+      <h3 class="title is-3">The Student Life</h3>
+    </div>
+    <div class="columns margin-bottom-3">
+    <div class="column is-full">
+    <aside class="box">
+        <h4 class="title is-4"> The Claremont Colleges Student Life</h4>
+        <p class="margin-bottom-2">
+        Access latest news of the 7Cs from the TSL Newspaper.
+        </p>
+        <a class="button is-outlined is-info" href="https://tsl.news" target="_blank">Go to TSL</a>        </aside>
+    </aside>
+    </div>
+    </div>
+  </div>
 </div>
 
 <!--

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -50,32 +50,80 @@
   </div>
 </div> -->
 
-    <div class="margin-bottom-3 home-heading upcoming-events-header-container columns">
-      <div class="buttons ta-center column">
-      <h3 class="title is-3 upcoming-events-header">Upcoming Events</h3>
-        <a class="button is-outlined is-info" href="/events">See more events</a>
-        <a class="button is-outlined is-info" href="https://pomona.campuslabs.com/engage/">Submit an event</a>
+<div class="columns">
+  <div class="column">
+      <div class="margin-bottom-3 home-heading upcoming-events-header-container columns">
+        <div class="buttons column">
+        <h3 class="title is-3 upcoming-events-header">Upcoming Events</h3>
+          <a class="button is-outlined is-info" href="/events">See more events</a>
+          <a class="button is-outlined is-info" href="https://pomona.campuslabs.com/engage/">Submit an event</a>
+        </div>
       </div>
-    </div>
 
     <!-- Events slideshow for desktop screens -->
-    <div class="is-hidden-mobile">
-      <% if @events.length > 0 %>
-        <%= render 'components/slideshow', :id => "events-slideshow-desktop", :slideshow_options => {
-            :autoplay => true,
-            :arrows => false,
-            :dots => true,
-            :useTransform => true,
-            :easing => 'swing',
-            :fade => true
-        } do %>
-          <% @events.each_slice(3) do |list| %>
-            <div class="container events-slide">
-              <div class="columns">
-                <% list.each do |item| %>
+      <div class="is-hidden-mobile">
+        <% if @events.length > 0 %>
+          <%= render 'components/slideshow', :id => "events-slideshow-desktop", :slideshow_options => {
+              :autoplay => true,
+              :arrows => true,
+              :dots => true,
+              :useTransform => true,
+              :easing => 'swing',
+              :fade => true
+          } do %>
+            <% @events.each_slice(3) do |list| %>
+              <div class="container events-slide">
+                <div class="columns">
+                  <% list.each do |item| %>
+                    <% campus_background_color_class = bg_color_class(item)
+                    %>
+                    <div class="column is-4 event">
+                      <div class="box" style="height: 100%; display: inline-block;"> 
+                        <div class="event-info <%= campus_background_color_class %>">
+                          <p class="event-date-time"><%= item.start.strftime("%B %e") %>
+                            , <%= item.start.strftime("%l:%M%P") %>
+                            -<%= item.end.strftime("%l:%M%P") %></p>
+                          <p class="event-location"><%= item.location %><br></p>
+                        </div>
+                        <h4 class="title is-4">
+                          <a href="<%= url_for(item) %>"><%= item.name %></a>
+                        </h4>
+                        <p class="event-host is-4 ">
+                          <%= item.host %>
+                        </p>
+                      </div>
+                    </div>
+                  <% end %>
+                </div>
+              </div>
+            <% end %>
+          <% end %>
+        <% else %>
+          <div class="columns margin-bottom-3">
+            <div class="column">
+              <p>There are no events available.</p>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
+    <!-- Events slideshow for mobile screens -->
+      <div class="is-hidden-tablet is-hidden-desktop">
+        <% if @events.length > 0 %>
+          <%= render 'components/slideshow', :id => "events-slideshow-mobile", :slideshow_options => {
+              :autoplay => true,
+              :arrows => true,
+              :dots => true,
+              :useTransform => true,
+              :easing => 'swing',
+              :fade => true
+          } do %>
+            <% @events.each do |item| %>
+              <div class="container">
+                <div class="columns events-slide">
                   <% campus_background_color_class = bg_color_class(item)
                   %>
-                  <div class="column box is-4 event">
+                  <div class="column event">
                     <div class="event-info <%= campus_background_color_class %>">
                       <p class="event-date-time"><%= item.start.strftime("%B %e") %>
                         , <%= item.start.strftime("%l:%M%P") %>
@@ -85,68 +133,24 @@
                     <h4 class="title is-4">
                       <a href="<%= url_for(item) %>"><%= item.name %></a>
                     </h4>
-                    <p class="event-host is-4 ">
+                    <p class="event-host is-4">
                       <%= item.host %>
                     </p>
                   </div>
-                <% end %>
-              </div>
-            </div>
-          <% end %>
-        <% end %>
-      <% else %>
-        <div class="columns margin-bottom-3">
-          <div class="column ta-center">
-            <p>There are no events available.</p>
-          </div>
-        </div>
-      <% end %>
-    </div>
-
-    <!-- Events slideshow for mobile screens -->
-    <div class="is-hidden-tablet is-hidden-desktop">
-      <% if @events.length > 0 %>
-        <%= render 'components/slideshow', :id => "events-slideshow-mobile", :slideshow_options => {
-            :autoplay => true,
-            :arrows => false,
-            :dots => true,
-            :useTransform => true,
-            :easing => 'swing',
-            :fade => true
-        } do %>
-          <% @events.each do |item| %>
-            <div class="container">
-              <div class="columns events-slide">
-                <% campus_background_color_class = bg_color_class(item)
-                %>
-                <div class="column event">
-                  <div class="event-info <%= campus_background_color_class %>">
-                    <p class="event-date-time"><%= item.start.strftime("%B %e") %>
-                      , <%= item.start.strftime("%l:%M%P") %>
-                      -<%= item.end.strftime("%l:%M%P") %></p>
-                    <p class="event-location"><%= item.location %><br></p>
-                  </div>
-                  <h4 class="title is-4">
-                    <a href="<%= url_for(item) %>"><%= item.name %></a>
-                  </h4>
-                  <p class="event-host is-4">
-                    <%= item.host %>
-                  </p>
                 </div>
               </div>
-            </div>
+            <% end %>
           <% end %>
-        <% end %>
-      <% else %>
-        <div class="columns margin-bottom-3">
-          <div class="column">
-            <p>There are no events available.</p>
+        <% else %>
+          <div class="columns margin-bottom-3">
+            <div class="column">
+              <p>There are no events available.</p>
+            </div>
           </div>
-        </div>
-      <% end %>
-    </div>
+        <% end %>
+      </div>
+  </div>
 
-<div class="columns main-box">
   <div class="column">
     <div class="margin-bottom-2 home-heading">
       <h3 class="title is-3">Latest From ASPC</h3>
@@ -164,44 +168,7 @@
       </div>
     </div>
   </div>
-
-  <div class="column ">
-    <div class="margin-bottom-2 home-heading">
-      <h3 class="title is-3">The Student Life</h3>
-    </div>
-    <div class="columns margin-bottom-3">
-    <div class="column is-full">
-    <aside class="box">
-        <h4 class="title is-4"> The Claremont Colleges Student Life</h4>
-        <p class="margin-bottom-2">
-        Access latest news of the 7Cs from the TSL Newspaper.
-        </p>
-        <a class="button is-outlined is-info" href="https://tsl.news" target="_blank">Go to TSL</a>        </aside>
-    </aside>
-    </div>
-    </div>
-  </div>
 </div>
+   
 
-<!--
-<% if @news.length > 0 %>
-  <div class="columns tsl-articles">
-    <% @news.each do |article| %>
-      <div class="column is-4 tsl-article">
-        <div class="tsl-article-info">
-          <p><%= article[:date].strftime("%B %e, %Y") %></p>
-        </div>
-        <h4 class="title is-4">
-          <a href="<%= article[:link] %>" target="_blank"><%= article[:title] %></a></h4>
-        </h4>
-      </div>
-    <% end %>
-  </div>
-<% else %>
-  <div class="columns margin-bottom-3">
-    <div class="column">
-      <p>There are no articles available.</p>
-    </div>
-  </div>
-<% end %>
--->
+

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,7 +60,9 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.web_console.whitelisted_ips = ['10.0.2.2', '172.20.0.1']
+  config.web_console.whitelisted_ips = ['172.18.0.1','10.0.2.2', '172.20.0.1']
+
+
 
   config.action_mailer.default_url_options = { :host => 'localhost:3000', protocol: 'http' }
   config.action_mailer.delivery_method = :test


### PR DESCRIPTION
Change landing page's stylings: created the two columns “Latest News from ASPC” and “The Student Life” and surrounded both with a box instead of leaving them as two separate sections to reduce white space and add contrast.

Before:
<img width="1268" alt="Screen Shot 2023-02-06 at 6 49 07 PM" src="https://user-images.githubusercontent.com/79251745/217135437-4f31cc2e-7614-452b-88f5-a5e273aa1b76.png">

After:
<img width="1434" alt="Screen Shot 2023-02-04 at 6 59 22 PM" src="https://user-images.githubusercontent.com/79251745/217135784-dc0d34b4-fb5e-47b4-894b-c3c0f4172089.png">
