### PR TITLE
Feature/housing new layout

### DIFF
--- a/app/admin/housing_building.rb
+++ b/app/admin/housing_building.rb
@@ -1,7 +1,7 @@
 housing_building_page = Proc.new do
   menu parent: "Models"
 
-  permit_params :name, :slug, :description, :floor, :image
+  permit_params :name, :slug,:description, :floor, :image
 
   form do |f|
     f.inputs

--- a/app/admin/housing_building.rb
+++ b/app/admin/housing_building.rb
@@ -1,7 +1,7 @@
 housing_building_page = Proc.new do
   menu parent: "Models"
 
-  permit_params :name, :slug, :floor, :descrip, :image
+  permit_params :name, :slug, :description, :floor, :image
 
   form do |f|
     f.inputs
@@ -13,8 +13,9 @@ housing_building_page = Proc.new do
     attributes_table do
       row :name
       row :slug
+
+      row :description
       row :floor
-      row: descrip
       row :image do |building|
         image_tag url_for(building.image), :width => '50%'
       end

--- a/app/admin/housing_building.rb
+++ b/app/admin/housing_building.rb
@@ -1,7 +1,7 @@
 housing_building_page = Proc.new do
   menu parent: "Models"
 
-  permit_params :name, :slug, :floor, :image
+  permit_params :name, :slug, :floor, :descrip, :image
 
   form do |f|
     f.inputs
@@ -14,6 +14,7 @@ housing_building_page = Proc.new do
       row :name
       row :slug
       row :floor
+      row: descrip
       row :image do |building|
         image_tag url_for(building.image), :width => '50%'
       end

--- a/app/views/housing_rooms/show_buildings.html.erb
+++ b/app/views/housing_rooms/show_buildings.html.erb
@@ -82,53 +82,53 @@
 
 # <% @housing_buildings.sort_by{|b| b.name.downcase}.in_groups_of(3, false).each do |group| %>
 
-<div class="columns">
-  <div class="column">
-      <h1> North campus </h1>
-      # <div class="column is-4">
-        <div class="card">
-          <div class="card-image">
-              <figure class="image residence-hall-image">
-                <img src="<%= url_for(@housing_buildings[dialynas].image) rescue nil %>"/>
-              </figure>
-          </div>
-          <div class="card-content">
-            <div class="media">
-              <div class="media-content" style="
-                    display: flex;
-                    justify-content: space-between;
-              ">
-              <h5 class="title is-5 margin-bottom-2">
-              <%= @housing_buildings[dialynas].name %></h5>
-              <%= link_to "Rooms", show_housing_rooms_for_dorm_path(:dorm_id => @housing_buildings[dialynas].id), class: "button is-info is-outlined" %>
-              </div>
-          </div>
-        </div>
-      # </div>
-  </div>
+# <div class="columns">
+#   <div class="column">
+#       <h1> North campus </h1>
+#       # <div class="column is-4">
+#         <div class="card">
+#           <div class="card-image">
+#               <figure class="image residence-hall-image">
+#                 <img src="<%= url_for(@housing_buildings[dialynas].image) rescue nil %>"/>
+#               </figure>
+#           </div>
+#           <div class="card-content">
+#             <div class="media">
+#               <div class="media-content" style="
+#                     display: flex;
+#                     justify-content: space-between;
+#               ">
+#               <h5 class="title is-5 margin-bottom-2">
+#               <%= @housing_buildings[dialynas].name %></h5>
+#               <%= link_to "Rooms", show_housing_rooms_for_dorm_path(:dorm_id => @housing_buildings[dialynas].id), class: "button is-info is-outlined" %>
+#               </div>
+#           </div>
+#         </div>
+#       # </div>
+#   </div>
 
-  <div class="column">
-      <h1> South campus </h1>
-      # <div class="column is-4">
-        <div class="card">
-          <div class="card-image">
-              <figure class="image residence-hall-image">
-                <img src="<%= url_for(@housing_buildings[dialynas].image) rescue nil %>"/>
-              </figure>
-          </div>
-          <div class="card-content">
-            <div class="media">
-              <div class="media-content" style="
-                    display: flex;
-                    justify-content: space-between;
-              ">
-              <h5 class="title is-5 margin-bottom-2">
-              <%= @housing_buildings[dialynas].name %></h5>
-              <%= link_to "Rooms", show_housing_rooms_for_dorm_path(:dorm_id => @housing_buildings[dialynas].id), class: "button is-info is-outlined" %>
-              </div>
-          </div>
-        </div>
-      # </div>
-  </div>
-</div>
+#   <div class="column">
+#       <h1> South campus </h1>
+#       # <div class="column is-4">
+#         <div class="card">
+#           <div class="card-image">
+#               <figure class="image residence-hall-image">
+#                 <img src="<%= url_for(@housing_buildings[dialynas].image) rescue nil %>"/>
+#               </figure>
+#           </div>
+#           <div class="card-content">
+#             <div class="media">
+#               <div class="media-content" style="
+#                     display: flex;
+#                     justify-content: space-between;
+#               ">
+#               <h5 class="title is-5 margin-bottom-2">
+#               <%= @housing_buildings[dialynas].name %></h5>
+#               <%= link_to "Rooms", show_housing_rooms_for_dorm_path(:dorm_id => @housing_buildings[dialynas].id), class: "button is-info is-outlined" %>
+#               </div>
+#           </div>
+#         </div>
+#       # </div>
+#   </div>
+# </div>
 # <% end %>

--- a/app/views/housing_rooms/show_buildings.html.erb
+++ b/app/views/housing_rooms/show_buildings.html.erb
@@ -2,133 +2,32 @@
   <%= render 'components/page_header', :title => "Housing Information" %>
 <% end %>
 
-# <% @housing_buildings.sort_by{|b| b.name.downcase}.in_groups_of(3, false).each do |group| %>
-#   <div class="columns">
-#     <% group.each do |building| %>
-#       <div class="column is-4">
-#         <div class="card">
-#           <div class="card-image">
-#             <figure class="image residence-hall-image">
-#               <img src="<%= url_for(building.image) rescue nil %>"/>
-#             </figure>
-#           </div>
-#           <div class="card-content">
-#             <div class="media">
-#               <div class="media-content" style="
-#               display: flex;
-#               justify-content: space-between;
-#           ">
-#                 <h5 class="title is-5 margin-bottom-2">
-#                   <%= building.name %></h5>
-#                 <%= link_to "Rooms", show_housing_rooms_for_dorm_path(:dorm_id => building.id), class: "button is-info is-outlined" %>
-#               </div>
-#             </div>
-#           </div>
-#         </div>
-#       </div>
-#     <% end %>
-#   </div>
-
-#   <div class="columns">
-#     <div class="column">
-#       <h1> North campus </h1>
-#       <div class="column is-4">
-#         <div class="card">
-#           <div class="card-image">
-#             <figure class="image residence-hall-image">
-#               <img src="<%= url_for(building.image) rescue nil %>"/>
-#             </figure>
-#           </div>
-#           <div class="card-content">
-#             <div class="media">
-#               <div class="media-content" style="
-#               display: flex;
-#               justify-content: space-between;
-#           ">
-#                 <h5 class="title is-5 margin-bottom-2">
-#                   <%= building.name %></h5>
-#                 <%= link_to "Rooms", show_housing_rooms_for_dorm_path(:dorm_id => building.id), class: "button is-info is-outlined" %>
-#               </div>
-#             </div>
-#           </div>
-#         </div>
-#         <div class="card">
-#           <div class="card-image">
-#             <figure class="image residence-hall-image">
-#               <img src="<%= url_for(building.image) rescue nil %>"/>
-#             </figure>
-#           </div>
-#           <div class="card-content">
-#             <div class="media">
-#               <div class="media-content" style="
-#               display: flex;
-#               justify-content: space-between;
-#           ">
-#               <h5 class="title is-5 margin-bottom-2">
-#                 <%= building.name %></h5>
-#               <%= link_to "Rooms", show_housing_rooms_for_dorm_path(:dorm_id => building.id), class: "button is-info is-outlined" %>
-#             </div>
-#           </div>
-#         </div>
-#       </div>
-#       </div>
-#     </div>
-#     <div class="column">
-#     </div>
-#   </div>
-# <% end %>
+<% @housing_buildings.sort_by{|b| b.slug.downcase}.in_groups_of(2, false).each do |group| %>
+  <div class="columns">
+    <% group.each do |building| %>
+      <div class="column is-6">
+        <div class="card">
+          <div class="card-image">
+            <figure class="image residence-hall-image">
+              <img src="<%= url_for(building.image) rescue nil %>"/>
+            </figure>
+          </div>
+          <div class="card-content">
+            <div class="media">
+              <div class="media-content" style="
+              display: flex;
+              justify-content: space-between;
+          ">
+                <h5 class="title is-5 margin-bottom-2">
+                  <%= building.name %></h5>
+                <%= link_to "Rooms", show_housing_rooms_for_dorm_path(:dorm_id => building.id), class: "button is-info is-outlined" %>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% end %>
 
 
-
-# <% @housing_buildings.sort_by{|b| b.name.downcase}.in_groups_of(3, false).each do |group| %>
-
-# <div class="columns">
-#   <div class="column">
-#       <h1> North campus </h1>
-#       # <div class="column is-4">
-#         <div class="card">
-#           <div class="card-image">
-#               <figure class="image residence-hall-image">
-#                 <img src="<%= url_for(@housing_buildings[dialynas].image) rescue nil %>"/>
-#               </figure>
-#           </div>
-#           <div class="card-content">
-#             <div class="media">
-#               <div class="media-content" style="
-#                     display: flex;
-#                     justify-content: space-between;
-#               ">
-#               <h5 class="title is-5 margin-bottom-2">
-#               <%= @housing_buildings[dialynas].name %></h5>
-#               <%= link_to "Rooms", show_housing_rooms_for_dorm_path(:dorm_id => @housing_buildings[dialynas].id), class: "button is-info is-outlined" %>
-#               </div>
-#           </div>
-#         </div>
-#       # </div>
-#   </div>
-
-#   <div class="column">
-#       <h1> South campus </h1>
-#       # <div class="column is-4">
-#         <div class="card">
-#           <div class="card-image">
-#               <figure class="image residence-hall-image">
-#                 <img src="<%= url_for(@housing_buildings[dialynas].image) rescue nil %>"/>
-#               </figure>
-#           </div>
-#           <div class="card-content">
-#             <div class="media">
-#               <div class="media-content" style="
-#                     display: flex;
-#                     justify-content: space-between;
-#               ">
-#               <h5 class="title is-5 margin-bottom-2">
-#               <%= @housing_buildings[dialynas].name %></h5>
-#               <%= link_to "Rooms", show_housing_rooms_for_dorm_path(:dorm_id => @housing_buildings[dialynas].id), class: "button is-info is-outlined" %>
-#               </div>
-#           </div>
-#         </div>
-#       # </div>
-#   </div>
-# </div>
-# <% end %>

--- a/app/views/housing_rooms/show_buildings.html.erb
+++ b/app/views/housing_rooms/show_buildings.html.erb
@@ -23,6 +23,8 @@
                 <%= link_to "Rooms", show_housing_rooms_for_dorm_path(:dorm_id => building.id), class: "button is-info is-outlined" %>
               </div>
             </div>
+            <p><%= building.description %></p>
+
           </div>
         </div>
       </div>

--- a/app/views/housing_rooms/show_buildings.html.erb
+++ b/app/views/housing_rooms/show_buildings.html.erb
@@ -2,27 +2,133 @@
   <%= render 'components/page_header', :title => "Housing Information" %>
 <% end %>
 
-<% @housing_buildings.sort_by{|b| b.name.downcase}.in_groups_of(3, false).each do |group| %>
-  <div class="columns">
-    <% group.each do |building| %>
-      <div class="column is-4">
+# <% @housing_buildings.sort_by{|b| b.name.downcase}.in_groups_of(3, false).each do |group| %>
+#   <div class="columns">
+#     <% group.each do |building| %>
+#       <div class="column is-4">
+#         <div class="card">
+#           <div class="card-image">
+#             <figure class="image residence-hall-image">
+#               <img src="<%= url_for(building.image) rescue nil %>"/>
+#             </figure>
+#           </div>
+#           <div class="card-content">
+#             <div class="media">
+#               <div class="media-content" style="
+#               display: flex;
+#               justify-content: space-between;
+#           ">
+#                 <h5 class="title is-5 margin-bottom-2">
+#                   <%= building.name %></h5>
+#                 <%= link_to "Rooms", show_housing_rooms_for_dorm_path(:dorm_id => building.id), class: "button is-info is-outlined" %>
+#               </div>
+#             </div>
+#           </div>
+#         </div>
+#       </div>
+#     <% end %>
+#   </div>
+
+#   <div class="columns">
+#     <div class="column">
+#       <h1> North campus </h1>
+#       <div class="column is-4">
+#         <div class="card">
+#           <div class="card-image">
+#             <figure class="image residence-hall-image">
+#               <img src="<%= url_for(building.image) rescue nil %>"/>
+#             </figure>
+#           </div>
+#           <div class="card-content">
+#             <div class="media">
+#               <div class="media-content" style="
+#               display: flex;
+#               justify-content: space-between;
+#           ">
+#                 <h5 class="title is-5 margin-bottom-2">
+#                   <%= building.name %></h5>
+#                 <%= link_to "Rooms", show_housing_rooms_for_dorm_path(:dorm_id => building.id), class: "button is-info is-outlined" %>
+#               </div>
+#             </div>
+#           </div>
+#         </div>
+#         <div class="card">
+#           <div class="card-image">
+#             <figure class="image residence-hall-image">
+#               <img src="<%= url_for(building.image) rescue nil %>"/>
+#             </figure>
+#           </div>
+#           <div class="card-content">
+#             <div class="media">
+#               <div class="media-content" style="
+#               display: flex;
+#               justify-content: space-between;
+#           ">
+#               <h5 class="title is-5 margin-bottom-2">
+#                 <%= building.name %></h5>
+#               <%= link_to "Rooms", show_housing_rooms_for_dorm_path(:dorm_id => building.id), class: "button is-info is-outlined" %>
+#             </div>
+#           </div>
+#         </div>
+#       </div>
+#       </div>
+#     </div>
+#     <div class="column">
+#     </div>
+#   </div>
+# <% end %>
+
+
+
+# <% @housing_buildings.sort_by{|b| b.name.downcase}.in_groups_of(3, false).each do |group| %>
+
+<div class="columns">
+  <div class="column">
+      <h1> North campus </h1>
+      # <div class="column is-4">
         <div class="card">
           <div class="card-image">
-            <figure class="image residence-hall-image">
-              <img src="<%= url_for(building.image) rescue nil %>"/>
-            </figure>
+              <figure class="image residence-hall-image">
+                <img src="<%= url_for(@housing_buildings[dialynas].image) rescue nil %>"/>
+              </figure>
           </div>
           <div class="card-content">
             <div class="media">
-              <div class="media-content">
-                <h5 class="title is-5 margin-bottom-2">
-                  <%= building.name %></h5>
-                <%= link_to "Rooms", show_housing_rooms_for_dorm_path(:dorm_id => building.id), class: "button is-info is-outlined" %>
+              <div class="media-content" style="
+                    display: flex;
+                    justify-content: space-between;
+              ">
+              <h5 class="title is-5 margin-bottom-2">
+              <%= @housing_buildings[dialynas].name %></h5>
+              <%= link_to "Rooms", show_housing_rooms_for_dorm_path(:dorm_id => @housing_buildings[dialynas].id), class: "button is-info is-outlined" %>
               </div>
-            </div>
           </div>
         </div>
-      </div>
-    <% end %>
+      # </div>
   </div>
-<% end %>
+
+  <div class="column">
+      <h1> South campus </h1>
+      # <div class="column is-4">
+        <div class="card">
+          <div class="card-image">
+              <figure class="image residence-hall-image">
+                <img src="<%= url_for(@housing_buildings[dialynas].image) rescue nil %>"/>
+              </figure>
+          </div>
+          <div class="card-content">
+            <div class="media">
+              <div class="media-content" style="
+                    display: flex;
+                    justify-content: space-between;
+              ">
+              <h5 class="title is-5 margin-bottom-2">
+              <%= @housing_buildings[dialynas].name %></h5>
+              <%= link_to "Rooms", show_housing_rooms_for_dorm_path(:dorm_id => @housing_buildings[dialynas].id), class: "button is-info is-outlined" %>
+              </div>
+          </div>
+        </div>
+      # </div>
+  </div>
+</div>
+# <% end %>

--- a/db/migrate/20230227055635_add_description_to_housing_buildings.rb
+++ b/db/migrate/20230227055635_add_description_to_housing_buildings.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToHousingBuildings < ActiveRecord::Migration[5.2]
+  def change
+    add_column :housing_buildings, :description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_07_230134) do
+ActiveRecord::Schema.define(version: 2023_02_27_055635) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -190,10 +190,10 @@ ActiveRecord::Schema.define(version: 2022_11_07_230134) do
   create_table "housing_buildings", force: :cascade do |t|
     t.string "name", null: false
     t.string "slug"
-    t.string "description"
     t.integer "floors", default: 1, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "description"
     t.index ["name"], name: "index_housing_buildings_on_name", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -190,6 +190,7 @@ ActiveRecord::Schema.define(version: 2022_11_07_230134) do
   create_table "housing_buildings", force: :cascade do |t|
     t.string "name", null: false
     t.string "slug"
+    t.string "description"
     t.integer "floors", default: 1, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
* Added a new column "description" in the admin portal to put a description for each housing card on the housing page. 
* Aligned the "Rooms" button next to the name of the building. 
* (To be added: slide shows of pictures)

Before:
<img width="325" alt="Screen Shot 2023-02-26 at 10 16 33 PM" src="https://user-images.githubusercontent.com/79251745/221488699-a72e60fa-1e72-4a37-b0a1-84bbda9fb335.png">

After:
<img width="493" alt="Screen Shot 2023-02-26 at 10 15 41 PM" src="https://user-images.githubusercontent.com/79251745/221488625-dd4a26c4-c1cd-4133-8ffa-067dd78aed91.png">
