### PR TITLE
Added link to summer storage details on navbar

### DIFF
--- a/app/views/components/_application_header.html.erb
+++ b/app/views/components/_application_header.html.erb
@@ -100,7 +100,7 @@
                   <%= link_to "Agenda Item Submission", "https://docs.google.com/forms/d/e/1FAIpQLSffo2Ji5N1ceL3WiB0Ddn75yeSvgzz05Za3eV826BGjwtVyBQ/viewform", :class => "navbar-item" %>
                 </div>
                 <div class="navbar-content">
-                  <%= link_to "Hybrid Learning Statement", static_path(page_name: "hybrid-learning"), :class => "navbar-item" %>
+                  <%= link_to "Summer Storage Details", static_path(page_name: "summer-storage"), :class => "navbar-item" %>
                 </div>
                 <div class="navbar-content">
                   <%= link_to "COVID Community Agreement", static_path(page_name: "covid-19"), :class => "navbar-item" %>


### PR DESCRIPTION
### After

<img width="1512" alt="Screenshot 2023-04-20 at 4 39 20 PM" src="https://user-images.githubusercontent.com/74080246/233508439-3a31a675-0f2e-471c-be1d-307b53bf382c.png">
