### PR TITLE
Fix slider conflicts between housing columns

### DIFF
--- a/app/views/housing_rooms/show_buildings.html.erb
+++ b/app/views/housing_rooms/show_buildings.html.erb
@@ -20,13 +20,13 @@
           <div class="card-image">
             <figure class="image residence-hall-image">
               <div class="housing-carousel">
-                <div id=<%= building.name %> class="carousel slide" data-ride="carousel">
+                <div id=<%= building.name.gsub(' ', '-') %> class="carousel slide" data-ride="carousel">
                   <ol class="carousel-indicators">
-                    <li data-target=#<%= building.name %>data-slide-to="0" class="active"></li>
-                    <li data-target=#<%= building.name %> data-slide-to="1"></li>
-                    <li data-target=#<%= building.name %> data-slide-to="2"></li>
-                    <li data-target=#<%= building.name %> data-slide-to="3"></li>
-                    <li data-target=#<%= building.name %> data-slide-to="4"></li>
+                    <li data-target=#<%= building.name.gsub(' ', '-') %>data-slide-to="0" class="active"></li>
+                    <li data-target=#<%= building.name.gsub(' ', '-') %> data-slide-to="1"></li>
+                    <li data-target=#<%= building.name.gsub(' ', '-') %> data-slide-to="2"></li>
+                    <li data-target=#<%= building.name.gsub(' ', '-') %> data-slide-to="3"></li>
+                    <li data-target=#<%= building.name.gsub(' ', '-') %> data-slide-to="4"></li>
                   </ol>
                   <div class="housing-carousel carousel-inner">
                     <div class="carousel-item active">
@@ -45,11 +45,11 @@
                   <img src="<%= url_for(building.image5) rescue nil %>"/>
                 </div>
                   </div>
-                  <a class="carousel-control-prev" href=#<%= building.name %> role="button" data-slide="prev">
+                  <a class="carousel-control-prev" href=#<%= building.name.gsub(' ', '-') %> role="button" data-slide="prev">
                     <span class="carousel-control-prev-icon" aria-hidden="true"></span>
                     <span class="sr-only">Previous</span>
                   </a>
-                  <a class="carousel-control-next" href=#<%= building.name %> role="button" data-slide="next">
+                  <a class="carousel-control-next" href=#<%= building.name.gsub(' ', '-') %> role="button" data-slide="next">
                     <span class="carousel-control-next-icon" aria-hidden="true"></span>
                     <span class="sr-only">Next</span>
                   </a>
@@ -92,13 +92,13 @@
           <div class="card-image">
             <figure class="image residence-hall-image">
               <div class="housing-carousel">
-                <div id=<%= building.name %> class="carousel slide" data-ride="carousel">
+                <div id=<%= building.name.gsub(' ', '-') %> class="carousel slide" data-ride="carousel">
                   <ol class="carousel-indicators">
-                    <li data-target=#<%= building.name %>data-slide-to="0" class="active"></li>
-                    <li data-target=#<%= building.name %> data-slide-to="1"></li>
-                    <li data-target=#<%= building.name %> data-slide-to="2"></li>
-                    <li data-target=#<%= building.name %> data-slide-to="3"></li>
-                    <li data-target=#<%= building.name %> data-slide-to="4"></li>
+                    <li data-target=#<%= building.name.gsub(' ', '-') %>data-slide-to="0" class="active"></li>
+                    <li data-target=#<%= building.name.gsub(' ', '-') %> data-slide-to="1"></li>
+                    <li data-target=#<%= building.name.gsub(' ', '-') %> data-slide-to="2"></li>
+                    <li data-target=#<%= building.name.gsub(' ', '-') %> data-slide-to="3"></li>
+                    <li data-target=#<%= building.name.gsub(' ', '-') %> data-slide-to="4"></li>
                   </ol>
                   <div class="housing-carousel carousel-inner">
                     <div class="carousel-item active">
@@ -117,11 +117,11 @@
                   <img src="<%= url_for(building.image5) rescue nil %>"/>
                 </div>
                   </div>
-                  <a class="carousel-control-prev" href=#<%= building.name %> role="button" data-slide="prev">
+                  <a class="carousel-control-prev" href=#<%= building.name.gsub(' ', '-') %> role="button" data-slide="prev">
                     <span class="carousel-control-prev-icon" aria-hidden="true"></span>
                     <span class="sr-only">Previous</span>
                   </a>
-                  <a class="carousel-control-next" href=#<%= building.name %> role="button" data-slide="next">
+                  <a class="carousel-control-next" href=#<%= building.name.gsub(' ', '-') %> role="button" data-slide="next">
                     <span class="carousel-control-next-icon" aria-hidden="true"></span>
                     <span class="sr-only">Next</span>
                   </a>


### PR DESCRIPTION
**Bug Description:**
The slider for buildings such as Clark I, III, and IV conflicted because the building.name ID tag only captured the first word in the string from the data frame. As a result, all three buildings were assigned the same ID, "Clark," causing conflicts in the slider.

**Solution:**
Changed the ID tag from 'building.name' to 'building.name.gsub(' ', '-')', which replaces spaces with hyphens and concatenates the string. Each building now has an unique identifier in the slider.
