### PR TITLE
Fix docker bundler version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get -y install build-essential git nginx postgresql libpq-dev python-dev
     imagemagick chromium
 
 #To correct bundler 2 error https://stackoverflow.com/questions/53231667/bundler-you-must-use-bundler-2-or-greater-with-this-lockfile
+# To fix bundler requires Ruby version >= version error : RUN gem install bundler -v '2.4.22', see https://github.com/rubygems/bundler/issues/6865
 RUN gem install bundler 
 
 WORKDIR /aspc

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,7 @@ RUN apt-get -y install build-essential git nginx postgresql libpq-dev python-dev
     imagemagick chromium
 
 #To correct bundler 2 error https://stackoverflow.com/questions/53231667/bundler-you-must-use-bundler-2-or-greater-with-this-lockfile
-# To fix bundler requires Ruby version >= version error : RUN gem install bundler -v '2.4.22', see https://github.com/rubygems/bundler/issues/6865
-RUN gem install bundler 
+RUN gem install bundler -v '2.4.22' 
 
 WORKDIR /aspc
 


### PR DESCRIPTION
## Description

When running the Docker commands to set up one's local development environment, new developers were running into an error indicating `bundler requires Ruby version >= __`. To fix this, we specify the bundler version in the Dockerfile, as suggested in the discussion here: https://github.com/rubygems/bundler/issues/6865

## Test
- tested running docker commands locally on multiple computers