### PR TITLE
changed name to p-recs

### DIFF
--- a/app/views/components/_application_header.html.erb
+++ b/app/views/components/_application_header.html.erb
@@ -137,6 +137,9 @@
           <span class="item-has-arrow">Courses</span>
         </div>
         <div class="navbar-dropdown">
+        <div class="navbar-content">
+            <a href="https://www.p-recs.com/" class="navbar-item">p-recs</a>
+          </div>
           <div class="navbar-content">
             <%= link_to "Course Planner", :course_planner, :class => "navbar-item" %>
           </div>


### PR DESCRIPTION
added p-recs to navigation bar: current name is set as "p-recs" but wondering whether it should be "AI-Course Recommender" instead 

https://github.com/aspc/aspc-website/assets/113216427/d945a12a-e233-489c-b348-067c96b6e902

