### PR TITLE
limit image size to 5MB each

### DIFF
--- a/app/models/housing_review.rb
+++ b/app/models/housing_review.rb
@@ -4,8 +4,19 @@ class HousingReview < ApplicationRecord
 
   validates :housing_room, presence: true
   has_many_attached :images
+  validate :validate_image_size
 
   def written_at
     self.created_at.strftime("%B %Y")
+  end
+
+  private
+
+  def validate_image_size
+    images.each do |image|
+      if image.byte_size > 5.megabytes
+        errors.add(:images, "A file uploaded exceeds the maximum allowed size of 5MB.")
+      end
+    end
   end
 end

--- a/app/views/housing_reviews/_form.html.erb
+++ b/app/views/housing_reviews/_form.html.erb
@@ -52,7 +52,7 @@
   </div>
 
   <div class="field">
-  <%= form.label "images", "Images of the room:" %>
+  <%= form.label "images", "Images of the room (up to 5MB each):" %>
     <div class="control">
     <%= form.file_field :images, multiple: true, accept: 'image/jpeg,image/png', :placeholder => "Upload your file" %>
     </div>


### PR DESCRIPTION
## Description

For the new housing review image upload, we want to limit the size of the user's images to prevent large storage use and slowdown. Here we limit file size to up to 5MB per image. 

Once user clicks submit on form, we validate the image size. If the size is too big, an error is shown to the user and the user must re-rate the stars and upload photos (but their text persists).

## Test
- tested locally adding greater and less than 5MB images


https://github.com/aspc/aspc-website/assets/69527053/3fa966b4-35cc-44b3-88fe-9fe10eb6c817



