### PR TITLE
Add sorting by ratings functionality to course reviews

### DIFF
--- a/app/controllers/course_reviews_controller.rb
+++ b/app/controllers/course_reviews_controller.rb
@@ -110,6 +110,10 @@ class CourseReviewsController < ApplicationController
     #     .where("name ILIKE ANY ( array[?] )", keywords_query)
     # end
 
+    if params[:sort_button]
+      matches_query = matches_query.sort_by {|course| -course.overall_rating}
+    end
+
     # server response
     @courses = matches_query.uniq
     respond_to do |format|

--- a/app/views/course_reviews/partials/_reviews_course_search_form.html.erb
+++ b/app/views/course_reviews/partials/_reviews_course_search_form.html.erb
@@ -62,9 +62,35 @@
       </div>
       -->
       <div class="field">
-        <%= f.button "Search", :class => "button is-link search-button margin-bottom-0 is-medium is-info",
-            :data => { disable_with: "<i class='fa fa-spinner fa-spin'></i>&nbspLoading".html_safe} %>
+        <%= f.button "Search", id: "search_button", :class => "button is-link search-button margin-bottom-0 is-medium is-info" %>
+      </div>
+      
+      <!-- Sort button -->
+      <div class="field">
+        <%= f.button "Sort by Rating", id: "sort_button", :name => "sort_button", :class => "button is-link search-button margin-bottom-0 is-medium is-info" %>
       </div>
     <% end %>
   </div>
 </section>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    $('#search_button').on('click', function() {
+      var $button = $(this);
+      $button.html('<i class="fa fa-spinner fa-spin"></i>&nbsp;Searching');
+      
+      setTimeout(function() {
+        $button.html('Search');
+      }, 3000); 
+    });
+
+    $('#sort_button').on('click', function() {
+      var $button = $(this);
+      $button.html('<i class="fa fa-spinner fa-spin"></i>&nbsp;Sorting');
+      
+      setTimeout(function() {
+        $button.html('Sort by Rating');
+      }, 3000); 
+    });
+  });
+</script>

--- a/app/views/course_reviews/partials/_reviews_course_search_form.html.erb
+++ b/app/views/course_reviews/partials/_reviews_course_search_form.html.erb
@@ -67,7 +67,7 @@
       
       <!-- Sort button -->
       <div class="field">
-        <%= f.button "Sort by Rating", id: "sort_button", :name => "sort_button", :class => "button is-link search-button margin-bottom-0 is-medium is-info" %>
+        <%= f.button "Sort by Rating", id: "sort_button", :name => "sort_button", :class => "button is-link search-button margin-bottom-0 is-medium is-info is-outlined" %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
## Description
We want to be able to sort course reviews by overall rating. To do this:
1. We modify the form review_course_search to include the button "Sort by Rating". When the user clicks the button, the form will be submitted with a flag param called `sort_button`.
2. We change the course_reviews_controller's `search_course_reviews` function to check whether the request has the params `sort_button`; If yes, we sort the courses by overall rating in descending order.

```
if params[:sort_button]
      matches_query = matches_query.sort_by {|course| -course.overall_rating}
end
```


https://github.com/aspc/aspc-website/assets/79251745/43321a26-7a38-4de2-95c0-374bd80c2dc9


## Test
Tested locally